### PR TITLE
Create roles in seeds instead of as a separate task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ mailcatcher &
 # Start the server
 rails s
 
-# For prodution
-rake db:create_roles
-
 # For Development
 # Create some development data to play arond with
 # This includes creating roles

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+
+%w{Admin Host}.each {|r| Role.create(name: r) }

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,17 +1,9 @@
 namespace :db do
-  desc "Creates roles for dev database"
-  task :create_roles => :environment do
-    %w{Admin Host}.each {|r| Role.create(name: r) }
-  end
-
   desc 'Create some play data for development database. Safe to run multiple times'
   task :seed_dev => :environment do
 
     puts "Resetting database"
     %x[rake db:reset]
-
-    puts "Creating roles"
-    %x[rake db:create_roles]
 
     puts "Loading seeds_dev"
     load "#{Rails.root}/db/seeds_dev.rb"


### PR DESCRIPTION
This is a perfect use case for the seeds file.
Seeds are only 'planted' once when the database is created
we shouldn't need a separate task for this.

This will also make it easier to set up a dev environment
