### PR TITLE
Clear ActiveMailer deliveries after all specs

### DIFF
--- a/spec/mailers/attendance_mailer_spec.rb
+++ b/spec/mailers/attendance_mailer_spec.rb
@@ -1,36 +1,34 @@
 require 'spec_helper'
 
 describe AttendanceMailer do
-  before(:all) do
-    @tt = create(:tea_time)
-    @attendance = create(:attendance, tea_time: @tt)
-  end
+  let(:tt) { create(:tea_time) }
+  let(:attendance) { create(:attendance, tea_time: tt) }
 
   describe '.reminder' do
     context 'flaked attendees' do
       it "shouldn't be sent a reminder" do
-        @attendance.update_column(:status, 1)
-        AttendanceMailer.reminder(@attendance.id, :same_day).deliver
+        attendance.update_column(:status, 1)
+        AttendanceMailer.reminder(attendance.id, :same_day).deliver
         #Flake mails get created, reminder shouldn't be
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
     end
     
     let(:mail) {
-      AttendanceMailer.reminder(@attendance.id, :same_day)
+      AttendanceMailer.reminder(attendance.id, :same_day)
     }
 
     it 'should come from the host' do
-      expect(mail.from).to eq([@tt.host.email])
+      expect(mail.from).to eq([tt.host.email])
     end
 
     it 'should be sent to attendee' do
-      expect(mail.to).to eq([@attendance.user.email])
+      expect(mail.to).to eq([attendance.user.email])
     end
 
     it 'should contain tea time and host info' do
-      expect(mail.body.encoded).to match(@tt.friendly_time)
-      expect(mail.body.encoded).to match(@tt.host.name)
+      expect(mail.body.encoded).to match(tt.friendly_time)
+      expect(mail.body.encoded).to match(tt.host.name)
     end
   end
 
@@ -38,7 +36,7 @@ describe AttendanceMailer do
   #attendance_spec when possible
   describe '.flake' do
     it 'should be sent when .flake! is called' do
-      @attendance.flake!
+      attendance.flake!
       expect(ActionMailer::Base.deliveries.size).to eq(1)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,4 +57,5 @@ RSpec.configure do |config|
   config.include IntegrationHelpers, :type => :feature
 
   config.before(:all) { ActiveRecord::Base.skip_callbacks = true }
+  config.before(:each) { ActionMailer::Base.deliveries.clear }
 end


### PR DESCRIPTION
ActiveMailer is set to clear the deliveries array after Mailer specs run,
but not after request or controller specs. This causes the array to be
prepopulated when specs run after a request or controller array that
creates mail. This fixes that.

Also switches to using lets in the attendance mailer spec for increased
clarity
