### PR TITLE
Fix 5th attendee of TT being waitlisted

### DIFF
--- a/app/controllers/tea_times_controller.rb
+++ b/app/controllers/tea_times_controller.rb
@@ -49,7 +49,7 @@ class TeaTimesController < ApplicationController
       end
     end
 
-    @attendance = Attendance.where(tea_time: @tea_time, user: @user).first_or_create
+    @attendance = Attendance.where(tea_time: @tea_time, user: @user).first_or_initialize
     @attendance.try_join
 
     if @attendance.save

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -18,7 +18,7 @@ class Attendance < ActiveRecord::Base
 
   def flake!
     unless flake?
-      unless tea_time.spots_remaining?
+      if !tea_time.spots_remaining?
         tea_time.send_waitlist_notifications
       end
       update_attribute(:status, :flake)


### PR DESCRIPTION
Problem was caused by setting default attendance status to :pending.
Fix: Don't persist attendance until `try_join` is called and its status
is set.

Nit: Swapped usage of unless for an 'if !'. It's cleaner.

Fixes #228.
