### PR TITLE
Cancelling Tea Time only affects Pending Attendees

### DIFF
--- a/app/models/tea_time.rb
+++ b/app/models/tea_time.rb
@@ -71,14 +71,14 @@ class TeaTime < ActiveRecord::Base
   def waitlisted?(user)
     !attendances.where(user: user, status: Attendance.statuses[:waiting_list]).empty?
   end
-  
+
   #Attendees takes an optional single argument lambda via the :filter keyword arg
   # that is passed to reject. Any items for which the Proc returns true are
   # excluded from the returned list of attendees.
   def attendees(filter: nil)
     attendances.reject(&filter).map(&:user)
   end
-  
+
   #Takes :filter, same as attendees
   def attendee_emails(filter: nil)
     attendees(filter: filter).map(&:email).join(',')
@@ -90,9 +90,10 @@ class TeaTime < ActiveRecord::Base
 
   def cancel!
     unless cancelled?
-      attendances.map { |att| att.update_attribute(:status, :cancelled) }
-      self.update_attribute(:followup_status, :cancelled)
-      true
+      attendances.map do |att|
+        att.update_attribute(:status, :cancelled) if att.pending?
+      end
+      return self.update_attribute(:followup_status, :cancelled)
     else
       false
     end
@@ -143,7 +144,7 @@ class TeaTime < ActiveRecord::Base
 
     def reparse_time_in_tz(time)
       use_city_timezone do
-        fmt = "%Y-%m-%d %H:%M" 
+        fmt = "%Y-%m-%d %H:%M"
         time.strftime(fmt)
         Time.zone.parse(time.strftime(fmt))
       end

--- a/app/services/cancel_tea_time.rb
+++ b/app/services/cancel_tea_time.rb
@@ -9,7 +9,7 @@ class CancelTeaTime
   end
 
   def self.send_cancellations(tea_time)
-    tea_time.attendances.each do |att|
+    tea_time.attendances.select { |x| x.cancelled? || x.pending? }.each do |att|
       TeaTimeMailer.delay.cancellation(tea_time.id, att.id)
     end
   end

--- a/spec/services/cancel_tea_time_spec.rb
+++ b/spec/services/cancel_tea_time_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper.rb'
 
 describe CancelTeaTime do
   let(:tt) { create(:tea_time, :attended) }
+  let(:flake) { create(:attendance, :flake, tea_time: tt) }
 
   describe '#call' do
     it 'should cancel the tea time and associated attendances' do
@@ -10,11 +11,12 @@ describe CancelTeaTime do
       expect(tt.attendances.first.cancelled?).to eq true
     end
   end
-  
+
   describe '#send_cancellations' do
     it 'should send cancellations to affected attendees' do
       CancelTeaTime.send_cancellations(tt)
-      expect(ActionMailer::Base.deliveries.count).to eq tt.attendances.count
+      expect(ActionMailer::Base.deliveries.count).to eq tt.attendances.select(&:pending?).count
+      expect(ActionMailer::Base.deliveries.map(&:to)).not_to include(flake.user.email)
     end
   end
 end


### PR DESCRIPTION
Only change attendance status on pending attendees when a tea time
is cancelled.

Fixes #237
