### PR TITLE
Stylish Sign Up Modal

### DIFF
--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -21,6 +21,10 @@ function loadModal(modalTarget) {
 function closeModal() { modal.dialog('close') }
 
 function modalActivation() {
+  $('a.sign-up').on('click', function(evt) { 
+    loadModal('/signup')(evt)
+  });
+
   $('#login').on('click', function(evt) { 
     loadModal('/signin')(evt)
   });

--- a/app/assets/javascripts/modals.js
+++ b/app/assets/javascripts/modals.js
@@ -14,6 +14,7 @@ function loadModal(modalTarget) {
       draggable: false,
       resizeable: false,
       width: 500,
+      closeText: "Not now",
       title: null
     });
   }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,8 +10,8 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require_self
  *= require jquery-ui/dialog
+ *= require_self
  */
 
 @import "tws-styles/application";

--- a/app/assets/stylesheets/static/_modal.scss
+++ b/app/assets/stylesheets/static/_modal.scss
@@ -1,0 +1,10 @@
+.ui-dialog-titlebar {
+  padding: 0;
+  border: 0;
+  background: white;
+
+  .ui-dialog-titlebar-close {
+    border: none;
+    background: none;
+  }
+}

--- a/app/assets/stylesheets/static/_signup.scss
+++ b/app/assets/stylesheets/static/_signup.scss
@@ -1,0 +1,8 @@
+.full-sign-up {
+  form.sign-up {
+    @include media($tablet) {
+      @include shift(3);
+      @include span-columns(6);
+    }
+  }
+}

--- a/app/assets/stylesheets/static/_signup.scss
+++ b/app/assets/stylesheets/static/_signup.scss
@@ -6,3 +6,9 @@
     }
   }
 }
+
+form.sign-up {
+  input[type='submit'] {
+    padding: 1.5em 0;
+  }
+}

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -27,4 +27,15 @@ class StaticController < ApplicationController
 
   def hosting
   end
+
+  def jfdi_signup
+    use_new_styles
+    @full_form = !request.xhr?
+    return redirect_to profile_path if current_user
+    if @full_form
+      render 'registrations/sign_up'
+    else
+      render 'shared/_new_sign_up', layout: @full_form
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ActiveRecord::Base
   has_attached_file :avatar, styles: { medium: "300x300", thumb: "100x100", landscape: "500"}, default_url: "/assets/missing.jpg"
   validates_attachment_content_type :avatar, :content_type => /\Aimage\/.*\Z/
 
-  validates_presence_of :home_city_id, :nickname
+  validates_presence_of :nickname
 
   include ActiveModel::Validations
   validates_with Validators::FacebookUrlValidator
@@ -40,6 +40,10 @@ class User < ActiveRecord::Base
 
   def name=(name)
     nickname = name
+  end
+
+  def home_city
+    read_attribute(:home_city_id).nil? ? City.first : super
   end
 
   def twitter_url

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,5 +45,6 @@
       ga('create', 'UA-39634305-2', 'teawithstrangers.com');
       ga('send', 'pageview');
     </script>
+    <div id="modal"></div>
   </body>
 </html>

--- a/app/views/registrations/sign_up.html.erb
+++ b/app/views/registrations/sign_up.html.erb
@@ -1,0 +1,3 @@
+<div class="container full-sign-up">
+  <%= render partial: 'shared/new_sign_up' %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
             <li class="nav-link-item"><%= link_to li[0], li[1] %></li>
           <% end %>
           <li class="nav-link-item">
-            <%= link_to_if(current_user.nil?, 'Sign In', new_user_session_path, class: 'sign-in-emphasis') do
+            <%= link_to_if(current_user.nil?, 'Sign In', new_user_session_path, id: 'login', class: 'sign-in-emphasis') do
               link_to('My Account', profile_path)
             end %>
     </ul>

--- a/app/views/shared/_new_sign_up.html.erb
+++ b/app/views/shared/_new_sign_up.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: ['sign-up' ] }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: ['sign-up'] }) do |f| %>
   <%= f.text_field :nickname, placeholder: 'Nickname' %>
   <%= f.email_field :email, placeholder: 'Email Address' %>
   <%= f.password_field :password, placeholder: 'Password' %>

--- a/app/views/shared/_new_sign_up.html.erb
+++ b/app/views/shared/_new_sign_up.html.erb
@@ -2,5 +2,5 @@
   <%= f.text_field :nickname, placeholder: 'Nickname' %>
   <%= f.email_field :email, placeholder: 'Email Address' %>
   <%= f.password_field :password, placeholder: 'Password' %>
-  <%= f.submit "Let's Go!" %>
+  <%= f.submit "Let's Go!", class: 'orange' %>
 <% end %>

--- a/app/views/shared/_new_sign_up.html.erb
+++ b/app/views/shared/_new_sign_up.html.erb
@@ -1,0 +1,6 @@
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: ['sign-up' ] }) do |f| %>
+  <%= f.text_field :nickname, placeholder: 'Nickname' %>
+  <%= f.email_field :email, placeholder: 'Email Address' %>
+  <%= f.password_field :password, placeholder: 'Password' %>
+  <%= f.submit "Let's Go!" %>
+<% end %>

--- a/app/views/shared/_signup.html.haml
+++ b/app/views/shared/_signup.html.haml
@@ -1,5 +1,5 @@
 - if current_user.nil?
-  = form_for(resource, as: resource_name, url: registration_path(resource_name), class: 'signup') do |f|
+  = form_for(resource, as: resource_name, url: registration_path(resource_name), class: 'sign-up') do |f|
     = f.text_field :nickname, placeholder: 'Nickname'
     = f.email_field :email, placeholder: 'Email Address'
     - if dropdown ||= false

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -6,9 +6,11 @@
         Expand your world, one 
         real-life conversation at a time.
       </h2>
-      <button class='orange cover-photo-cta'>
-        <%= link_to 'Sign Up', '#' %>
-      </button>
+      <%= link_to sign_up_path, class: 'sign-up' do %>
+        <button class='orange cover-photo-cta'>
+          Sign Up
+        </button>
+      <% end %>
     </div>
   </div>
 </div>
@@ -61,9 +63,11 @@
       <h2>
         Ready to take the plunge?
       </h2>
-      <button class='orange cover-photo-cta'>
-        <%= link_to 'Sign Up', '#' %>
-      </button>
+      <%= link_to sign_up_path, class: 'sign-up' do %>
+        <button class='orange cover-photo-cta'>
+          Sign Up
+        </button>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/openhouse'      => 'static#openhouse',      as: :openhouse
   get '/questions'      => 'static#questions',      as: :questions
   get '/stories'        => 'static#stories',        as: :stories
+  get '/signup'         => 'static#jfdi_signup',    as: :sign_up
 
   # Devise and Registration Routes
   devise_for :users, :controllers => {:registrations => "registrations"}, :skip => [:sessions]


### PR DESCRIPTION
This adds a stylish sign up modal along with changes to the User Class that allow for setting `home_city` *after* you've signed up. It does *not* include any of the waitlisting features.

- [ ] Remove modal title bar
- [ ] Modal appears at wrong spot on page first time it's opened
- [ ] Ignore sign up integration tests – they should be handled separately as part of the waitlisting branch, but depend upon this branch.