### PR TITLE
Serve Assets from CDN

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
+  config.action_controller.asset_host = ENV['CDN_ASSET_HOST']
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
This allows the asset host to be reconfigured from an environment variable. For
now, it will be `http://dcu7hky3kqbj1.cloudfront.net`. If I manage to get a
CNAME set up by EoD, I'll switch it to `cdn.teawithstrangers.com` or similar.

Uploaded images (e.g. host, city photos) will still be served straight from S3 buckets.