### PR TITLE
Only show cold water, fully brewed and warming up cities

### DIFF
--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -18,11 +18,11 @@ class City < ActiveRecord::Base
 
   validate :proxy_city_not_self
 
-  scope :visible, ->(user = nil) { 
-    if (user && user.host?) 
-      all 
-    else 
-      where.not(brew_status: brew_statuses[:hidden]) 
+  scope :visible, ->(user = nil) {
+    if (user && user.host?)
+      all
+    else
+      where(brew_status: [brew_statuses[:cold_water], brew_statuses[:warming_up], brew_statuses[:fully_brewed]])
     end
   }
   scope :hidden, -> { where(brew_status: brew_statuses[:hidden]) }
@@ -39,7 +39,7 @@ class City < ActiveRecord::Base
   def timezone=(tz)
     val = tz if City.timezone_mappings.key? tz
     if val
-      write_attribute(:timezone, val) 
+      write_attribute(:timezone, val)
     else
      raise ArgumentError, "TimeZone must be one from TZinfo"
     end


### PR DESCRIPTION
I don't like the .visible scope. It is doing too much. The fact that is looks at the current user is not good design. The model should not be concerned with view permissions or view layer logic at all. 

This PR does *not* address this underlying problem, but it does change the logic to remove unapproved and rejected cities from the list. 