### PR TITLE
Add flash messages to new application layout template

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,8 @@
   <body class="<%= controller_name %> <%= action_name %>">
     <div class='wrapper'>
       <main class='wrapper-content'>
+        <!-- TODO render header partial here directly so we can also put flash messages here.
+            Flash messages currently live in the shared/header partial -->
         <%= yield %>
       </main>
       <% if content_for?(:footer) %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,3 +15,12 @@
     </nav>
   </div>
 </header>
+
+<!-- TODO flash messages are in this partial because we want them to be below
+      the header. But this header partial is currently rendered individually
+      in random templates, rather than the layout. -->
+<% flash.each do |key, value| %>
+  <div class="flash <%= key %>">
+    <%= value %>
+  </div>
+<% end %>


### PR DESCRIPTION
This adds flash messages to the template, right below the header. 

But there are no styles. 

@ankitshah811 you'll need to add the following css classes:

```css
.flash.notice {}
.flash.alert {}
```

The `flash` div will be rendered inside `.wrapper .wrapper-content`, so keep that in mind for positioning, etc. 