### PR TITLE
Add counter cache column to cities table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
 
   has_many :tea_times
   has_many :attendances
-  belongs_to :home_city, class_name: 'City'
+  belongs_to :home_city, class_name: 'City', counter_cache: true
   has_attached_file :avatar, styles: { medium: "300x300", thumb: "100x100", landscape: "500"}, default_url: "/assets/missing.jpg"
   validates_attachment_content_type :avatar, :content_type => /\Aimage\/.*\Z/
 

--- a/app/serializers/city_overview_serializer.rb
+++ b/app/serializers/city_overview_serializer.rb
@@ -2,6 +2,6 @@ class CityOverviewSerializer < ActiveModel::Serializer
   attributes :id, :name, :brew_status, :header_bg, :info, :city_code
 
   def info
-    { user_count: object.users.count }
+    { user_count: object.users_count }
   end
 end

--- a/db/migrate/20150520015332_add_users_count_cache_counter_column_to_cities.rb
+++ b/db/migrate/20150520015332_add_users_count_cache_counter_column_to_cities.rb
@@ -1,0 +1,5 @@
+class AddUsersCountCacheCounterColumnToCities < ActiveRecord::Migration
+  def change
+    add_column :cities, :users_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150510013715) do
+ActiveRecord::Schema.define(version: 20150520015332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20150510013715) do
     t.integer  "header_bg_file_size"
     t.datetime "header_bg_updated_at"
     t.integer  "suggested_by_user_id"
+    t.integer  "users_count",            default: 0
   end
 
   add_index "cities", ["city_code"], name: "city_code_idx", unique: true, using: :btree

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -8,4 +8,9 @@ namespace :db do
     puts "Loading seeds_dev"
     load "#{Rails.root}/db/seeds_dev.rb"
   end
+
+  desc "Update Cities users_count counter cache"
+  task update_users_counter_cache: :environment do
+    City.find_each { |city| City.reset_counters(city.id, :users) }
+  end
 end

--- a/spec/requests/api/v1/cities_request_spec.rb
+++ b/spec/requests/api/v1/cities_request_spec.rb
@@ -63,12 +63,16 @@ describe 'Cities endpoint', type: :request do
       @cities = FactoryGirl.create_list(:city, 5)
     end
 
+    let(:json_response) do
+      JSON.parse(response.body)
+    end
+
     let(:first_record) do
-      JSON.parse(response.body)['cities'].first
+      json_response['cities'].first
     end
 
     let(:returned_ids) do
-      JSON.parse(response.body)['cities'].map { |c| c['id'] }
+      json_response['cities'].map { |c| c['id'] }
     end
 
     it 'returns all the cities' do
@@ -76,6 +80,14 @@ describe 'Cities endpoint', type: :request do
       @cities.each do |city|
         expect(returned_ids).to include(city.id)
       end
+    end
+
+    it 'should return the users_count' do
+      target_test_city = @cities.first
+      new_users = FactoryGirl.create_list(:user, 2, home_city_id: target_test_city.id)
+      get '/api/v1/cities'
+      returned_target = json_response['cities'].find { |x| x['id'] == target_test_city.id }
+      expect(returned_target['info']['user_count']).to eq new_users.length
     end
 
     #expected_attributes = [:brew_status, :city_code, :description, :id, :name, :tagline, :timezone]


### PR DESCRIPTION
When this is deployed, it will require:

```
heroku run rake db:migrate
heroku run rake db:update_users_counter_cache
```

The problem with counter cache is that it doesn't update out of box when something like this happens:

```
City.first.users << User.create
```

I'm ok with this because (1) we don't really associate users with cities in this way. It's usually by assigning the `home_city_id` column. And secondly, if we do have a bad cache counter, it doesn't break anything terribly, just gives inaccurate numbers, which we can deal with then. 