### PR TITLE
Don't show rejected cities on /cities page

### DIFF
--- a/app/assets/javascripts/cities.js
+++ b/app/assets/javascripts/cities.js
@@ -53,7 +53,7 @@ var onCitiesIndexLoad = function() {
         if (city.brew_status === "fully_brewed") {
           listOfActiveCities.push(cityDiv);
           /*jshint camelcase: false */
-        } else if (!(city.brew_status === "unapproved") && !(city.brew_status === "hidden")) {
+        } else if (!(city.brew_status === "unapproved") && !(city.brew_status === "hidden") && !(city.brew_status === "rejected")) {
           listOfUpcomingCities.push(cityDiv);
 
         }


### PR DESCRIPTION
We should add query parameters to filter by brew status. This will make city serialization faster also (and thus the /cities page faster also). This is a temp solution. 