### PR TITLE
Improve logic for create/update button text.

### DIFF
--- a/app/assets/stylesheets/deprecated.less
+++ b/app/assets/stylesheets/deprecated.less
@@ -1474,23 +1474,13 @@ a {
           display: block;
         }
         .create-button {
-          display: none;
+          display: block;
         }
       }
       .controls {
         clear: both;
         width: 100%;
         overflow: auto;
-      }
-    }
-    &.edit .two-third {
-      .actions {
-        .update-button {
-          display: none;
-        }
-        .create-button {
-          display: block;
-        }
       }
     }
   }

--- a/app/views/tea_times/_form.html.erb
+++ b/app/views/tea_times/_form.html.erb
@@ -46,13 +46,14 @@
     <% end %>
   </div>
   <div class="actions">
-    <div class="create-button">
-      <%= f.submit 'Create Tea Time' %>
-    </div>
-  </div>
-  <div class="actions">
-    <div class="update-button">
-      <%= f.submit 'Update Tea Time' %>
-    </div>
+    <% if @tea_time.persisted? %>
+      <div class="update-button">
+        <%= f.submit 'Update Tea Time' %>
+      </div>
+    <% else %>
+      <div class="create-button">
+        <%= f.submit 'Create Tea Time' %>
+      </div>
+    <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
These buttons are identical except the CSS class and the button text.
Since I don't know if the classes are important and since I don't
want a grid level class to dictate hiding/showing an unrelated DOM element,
I am changing to using a pattern that is used elsewhere in the app
to determine if this is an edit or new form: the .persisted? method in the modl.

A better solution would be to have separate forms for new and edit
or to set a virtual attribute in the controller. But this is better
than the current solution and matches the pattern in other places