### PR TITLE
Add admin web interface to get introspection into delayed jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'time_zone_ext'
 #Background Jobs
 gem 'delayed_job', '~> 4.0.1'
 gem 'delayed_job_active_record', '~> 4.0.1'
+gem "delayed_job_web"
 
 # File Storage
 gem 'paperclip', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,10 @@ GEM
     delayed_job_active_record (4.0.3)
       activerecord (>= 3.0, < 5.0)
       delayed_job (>= 3.0, < 4.1)
+    delayed_job_web (1.2.10)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      sinatra (>= 1.4.4)
     devise (3.2.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -194,6 +198,8 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.1)
@@ -266,6 +272,10 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slop (3.6.0)
     spring (1.3.6)
     sprockets (3.0.3)
@@ -333,6 +343,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job (~> 4.0.1)
   delayed_job_active_record (~> 4.0.1)
+  delayed_job_web
   devise (~> 3.2.4)
   factory_girl (~> 4.4)
   factory_girl_rails

--- a/config.ru
+++ b/config.ru
@@ -2,3 +2,9 @@
 
 require ::File.expand_path('../config/environment',  __FILE__)
 run Rails.application
+
+if Rails.env.production?
+  DelayedJobWeb.use Rack::Auth::Basic do |username, password|
+    username == 'tws' && password == ENV['TWS_DELAYED_JOBS_ADMIN_PASSWORD']
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
     post '/mail'              => 'admin#send_mail'
     get '/host'               => 'hosts#new',                 as: :new_host
     post '/host'              => 'hosts#create',              as: :create_host
+    get "/jobs"               => DelayedJobWeb, :anchor => false, via: [:get, :post]
   end
 
   scope :profile do


### PR DESCRIPTION
To help with #529 

cc @ankitshah811. 

This gives us /admin/delayed_job to be able to see what reminders are scheduled. it's possible that the issue reported in #529 was just previous reminders that were already scheduled. Before the @nickbarnwell's fix in #521 