### PR TITLE
Customizable reminders

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'neat'
 
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 gem 'markerb'
+gem 'redcarpet', '>= 2.0'
 gem 'sendgrid'
 
 # Figaro makes it easy to set env variables without Foreman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,7 @@ DEPENDENCIES
   rails (= 4.1.1)
   rails-observers
   rails_12factor
+  redcarpet (>= 2.0)
   rspec-rails (~> 2.14.2)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/stylesheets/components/_dashboard-forms.scss
+++ b/app/assets/stylesheets/components/_dashboard-forms.scss
@@ -123,8 +123,14 @@ These are styles related to forms within the user or host dashboards
 		}
 	}
 }
-
-.form.create-tea, .form.edit-tea {
+.form.email-reminder {
+  textarea {
+    height: 300px;
+    font-size: 0.8em;
+    line-height: 1em;
+  }
+}
+.form.email-reminder, .form.create-tea, .form.edit-tea {
   .form-checkbox input[type="checkbox"] {
     display: inline-block;
     width: auto;
@@ -150,7 +156,7 @@ These are styles related to forms within the user or host dashboards
       font-size: 1em;
       margin-right: 5px;
     }
-		margin-bottom: 1em;
+    margin-bottom: 1em;
 
 		&.duration {
 			display: none;

--- a/app/assets/stylesheets/components/_dashboard-forms.scss
+++ b/app/assets/stylesheets/components/_dashboard-forms.scss
@@ -125,7 +125,31 @@ These are styles related to forms within the user or host dashboards
 }
 
 .form.create-tea, .form.edit-tea {
+  .form-checkbox input[type="checkbox"] {
+    display: inline-block;
+    width: auto;
+    margin:0px;padding:0px;
+    margin-top:-2px;
+    margin-left:-2px;
+    width:14px;
+    height:14px;
+  }
 	.field {
+    p.small {
+      font-size: 0.8em;
+    }
+    .border-circle {
+      border: solid 1px #000;
+      border-radius: 50%;
+      height: 22px;
+      width: 22px;
+      display: inline-block;
+      text-align: center;
+      padding: 0;
+      font-weight: 500;
+      font-size: 1em;
+      margin-right: 5px;
+    }
 		margin-bottom: 1em;
 
 		&.duration {

--- a/app/controllers/attendance_controller.rb
+++ b/app/controllers/attendance_controller.rb
@@ -30,9 +30,12 @@ class AttendanceController < ApplicationController
 
     if @attendance.save
 
-      # sends confirmation email AND queues 2 reminder emails for attendee
-      @attendance.send_mail
-
+      # Send various emails (Should all be run async)
+      @attendance.send_confirmation_mail  if @attendance.pending?
+      @attendance.queue_first_reminder    if @attendance.pending?
+      @attendance.queue_second_reminder   if @attendance.pending?
+      @attendance.send_ethos_mail         if (@attendance.pending? && @attendance.user.attendances.present.count.zero?)
+      @attendance.send_waitlist_mail      if @attendance.waiting_list?
 
       message = @attendance.waiting_list? ?
         "You're on the wait list! Check your email for details." :

--- a/app/mailers/attendance_mailer.rb
+++ b/app/mailers/attendance_mailer.rb
@@ -34,6 +34,8 @@ class AttendanceMailer < ActionMailer::Base
     body = tt.host.email_reminder.body
 
     cancel_delivery unless body
+    TeaTime.first.start_time
+    body += "\n\n <hr> *Note from the Robots: This email is about your tea time on #{tt.date_to_email}. It's at #{tt.location}. Enjoy it!*"
 
     # See here for options https://github.com/vmg/redcarpet
     renderer = Redcarpet::Render::HTML.new(filter_html: true, hard_wrap: true, escape_html: true)
@@ -47,6 +49,7 @@ class AttendanceMailer < ActionMailer::Base
     cancel_delivery unless @attendance.pending?
     mail(
       to:           @attendance.user.email,
+      from:         "\"#{tt.host.nickname} at Tea With Strangers\" <#{tt.host.email}>",
       subject:      "Your tea time is coming up!",
       body:         sanitized_body,
       content_type: "text/html")

--- a/app/mailers/attendance_mailer.rb
+++ b/app/mailers/attendance_mailer.rb
@@ -31,10 +31,14 @@ class AttendanceMailer < ActionMailer::Base
     @user = @attendance.user
     tt = @attendance.tea_time
 
-    # should be sanitized and turned into html from whatever format it is stored in
     body = tt.host.email_reminder.body
 
     cancel_delivery unless body
+
+    # See here for options https://github.com/vmg/redcarpet
+    renderer = Redcarpet::Render::HTML.new(filter_html: true, hard_wrap: true, escape_html: true)
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+    sanitized_body = markdown.render(body)
 
     attachments['event.ics'] = {
       mime_type: "text/calendar",
@@ -44,7 +48,7 @@ class AttendanceMailer < ActionMailer::Base
     mail(
       to:           @attendance.user.email,
       subject:      "Your tea time is coming up!",
-      body:         body,
+      body:         sanitized_body,
       content_type: "text/html")
   end
 

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -40,22 +40,17 @@ class Attendance < ActiveRecord::Base
     end
   end
 
-  def send_mail
-    if self.pending?
-      #Immediate Attendance Confirmation
-      AttendanceMailer.delay.registration(self.id)
+  def send_confirmation_mail
+    AttendanceMailer.delay.registration(self.id)
+  end
 
-      queue_first_reminder
-      queue_second_reminder
+  def send_waitlist_mail
+    AttendanceMailer.delay.waitlist(self.id)
+  end
 
-      #Ethos Email is sent when a user has never attended a tea time before
-      if user.attendances.present.count.zero?
-        TeaTimeMailer.delay(run_at: Time.now + 1.hour).ethos(self.user.id)
-      end
-
-    elsif self.waiting_list?
-      AttendanceMailer.delay.waitlist(self.id)
-    end
+  # TODO why is this run specifically 1 hour after creating attendance?
+  def send_ethos_mail
+    TeaTimeMailer.delay(run_at: Time.now + 1.hour).ethos(self.user_id)
   end
 
   # T - 2day reminder

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -62,7 +62,12 @@ class Attendance < ActiveRecord::Base
   def queue_first_reminder
     two_day_reminder = tea_time_start_time - 2.days
     if two_day_reminder.future?
-      AttendanceMailer.delay(run_at: two_day_reminder).reminder(self.id, :two_day)
+      if tea_time.use_custom_email_reminder && tea_time.host.email_reminder.present?
+        Rails.logger.info("Sending Custom First Reminder")
+        AttendanceMailer.delay(run_at: two_day_reminder).custom_first_reminder(self.id)
+      else
+        AttendanceMailer.delay(run_at: two_day_reminder).reminder(self.id, :two_day)
+      end
     end
   end
 

--- a/app/models/tea_time.rb
+++ b/app/models/tea_time.rb
@@ -40,6 +40,10 @@ class TeaTime < ActiveRecord::Base
     start_time.strftime("%A, %b %e")
   end
 
+  def date_to_email
+    start_time.strftime("%A, %b %e at %I:%M%P")
+  end
+
   def day
     start_time.strftime("%A")
   end

--- a/app/views/email_reminders/_form.html.erb
+++ b/app/views/email_reminders/_form.html.erb
@@ -1,7 +1,19 @@
-<%= form_for @email_reminder, url: @form_url, html: {class: "no-header tea-time"} do |f| %>
+<%= form_for @email_reminder, url: @form_url, html: {class: "tea-time"} do |f| %>
+  <h3 class="form-subheader">
+    Custom Email Reminder
+  </h3>
+  <div class="field">
+    <p class="small">
+      <span class="border-circle">?</span>
+      By default, your attendees get reminded about tea time 48hrs and 12hrs before it starts. These are from "The Robots at Tea With Strangers". You can customize the T-48hrs note to be from "<%= current_user.nickname %> at Tea With Strangers" to include any specific information and allow attendees to reply directly to you.
+      <br>
+    </p>
+  </div>
   <div class="field city">
     <div class="form-label">
-      <%= f.label :body, class: 'capitalize boldweight' %>
+      <%= f.label :body, class: 'capitalize boldweight' do %>
+        Draft
+      <% end %>
     </div>
     <%= f.text_area :body %>
   </div>

--- a/app/views/email_reminders/new.html.erb
+++ b/app/views/email_reminders/new.html.erb
@@ -1,10 +1,7 @@
 <%= render partial: 'shared/header' %>
 <%= render partial: 'profiles/navbar' %>
 <div class="dash-body">
-  <div class="create-tea form">
-    <h2>
-      Customize Email Reminder
-    </h2>
+  <div class="email-reminder form">
     <%= render 'form' %>
   </div>
 </div>

--- a/app/views/tea_times/_form.html.erb
+++ b/app/views/tea_times/_form.html.erb
@@ -1,5 +1,8 @@
 <% host_attributes = [:id, :nickname, :given_name, :family_name] %>
-<%= form_for @tea_time, :html => {:class => "no-header tea-time"} do |f| %>
+<%= form_for @tea_time, :html => {:class => "tea-time"} do |f| %>
+  <h3 class="form-subheader">
+    Time and Place
+  </h3>
   <div class="field datepicker">
     <div class="form-label">
       <%= f.label :start_time, class: 'capitalize boldweight' %>

--- a/app/views/tea_times/_form.html.erb
+++ b/app/views/tea_times/_form.html.erb
@@ -57,6 +57,29 @@
       </div>
     <% end %>
   </div>
+  <h3 class="form-subheader">
+    Reminder Emails
+  </h3>
+  <div class="field">
+    <p class="small">
+      <span class="border-circle">?</span>
+      By default, your attendees get reminded about tea time 48hrs and 12hrs before it starts. These are from "The Robots at Tea With Strangers". You can customize the T-48hrs note to be from "<%= current_user.nickname %> at Tea With Strangers" to include any specific information and allow attendees to reply directly to you.
+      <br>
+
+      <% if current_user.email_reminder.present? %>
+        <%= link_to "Update/View Custom T-48 email", customize_reminder_email_path %>
+        <div class="form-checkbox">
+          <%= check_box('tea_time', 'use_custom_email_reminder', options = {}, checked_value = "1", unchecked_value = "0") %>
+
+          <%= f.label :use_custom_email_reminder do %>
+            <strong>Use Custom Email Reminder 48 hrs before tea time?</strong>
+          <% end %>
+        </div>
+      <% else %>
+        <%= link_to "Set a Custom T-48 email", customize_reminder_email_path %>
+      <% end %>
+    </p>
+  </div>
   <div class="actions field">
     <% if @tea_time.persisted? %>
       <div class="update-button">

--- a/db/migrate/20150721083010_add_use_custom_email_reminder_on_tea_times.rb
+++ b/db/migrate/20150721083010_add_use_custom_email_reminder_on_tea_times.rb
@@ -1,0 +1,5 @@
+class AddUseCustomEmailReminderOnTeaTimes < ActiveRecord::Migration
+  def change
+    add_column :tea_times, :use_custom_email_reminder, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150721024624) do
+ActiveRecord::Schema.define(version: 20150721083010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,13 +93,14 @@ ActiveRecord::Schema.define(version: 20150721024624) do
   create_table "tea_times", force: true do |t|
     t.datetime "start_time"
     t.float    "duration"
-    t.integer  "followup_status", default: 0
+    t.integer  "followup_status",           default: 0
     t.text     "location"
     t.integer  "city_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
     t.datetime "deleted_at"
+    t.boolean  "use_custom_email_reminder", default: true
   end
 
   create_table "users", force: true do |t|

--- a/spec/models/attendance_spec.rb
+++ b/spec/models/attendance_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper.rb'
 
 describe Attendance do
+  it { expect(subject).to delegate_method(:start_time).to(:tea_time).with_prefix(true) }
+
   describe 'todo?' do
     it 'returns true when pending? is false' do
       attendance = create(:attendance)
@@ -51,18 +53,53 @@ describe Attendance do
     end
   end
 
-  describe '.queue_reminders' do
+  describe '.queue_first_reminder' do
     let!(:attendance) { build(:attendance) }
 
-    it 'should not queue a reminder after it should have been sent' do
+    it 'should not first second reminder after the tea time has started' do
       Time.stub(:now).and_return(attendance.tea_time.start_time + 1.hour)
       dj_count = Delayed::Job.count
-      attendance.queue_reminders
+      attendance.queue_first_reminder
       expect(Delayed::Job.count).to eq(dj_count)
+    end
 
+    it 'should not queue first reminder less than 48 hours before' do
+      Time.stub(:now).and_return(attendance.tea_time.start_time - 36.hour)
+      dj_count = Delayed::Job.count
+      attendance.queue_first_reminder
+      expect(Delayed::Job.count).to eq(dj_count)
+    end
+
+    it 'should queue first reminder 50 hours before' do
+      Time.stub(:now).and_return(attendance.tea_time.start_time - 50.hour)
+      dj_count = Delayed::Job.count
+      attendance.queue_first_reminder
+      expect(Delayed::Job.count).to eq(dj_count += 1)
+    end
+  end
+
+  describe '.queue_second_reminder' do
+    let!(:attendance) { build(:attendance) }
+
+    it 'should not queue second reminder after the tea time has started' do
+      Time.stub(:now).and_return(attendance.tea_time.start_time + 1.hour)
+      dj_count = Delayed::Job.count
+      attendance.queue_second_reminder
+      expect(Delayed::Job.count).to eq(dj_count)
+    end
+
+    it 'should not queue second reminder less than 12 hours before' do
+      Time.stub(:now).and_return(attendance.tea_time.start_time - 8.hour)
+      dj_count = Delayed::Job.count
+      attendance.queue_second_reminder
+      expect(Delayed::Job.count).to eq(dj_count)
+    end
+
+    it 'should queue the second reminder more than 12 hours before' do
       Time.stub(:now).and_return(attendance.tea_time.start_time - 13.hour)
-      attendance.queue_reminders
-      expect(Delayed::Job.count).to eq(dj_count.succ)
+      dj_count = Delayed::Job.count
+      attendance.queue_second_reminder
+      expect(Delayed::Job.count).to eq(dj_count += 1)
     end
   end
 


### PR DESCRIPTION
Summary:

1. Ability to use customized email when creating tea time
1. markdown syntax for customized email
1. some refactor to attendance emails

Notable things missing / limitations that will **not** be included in this release.

1. Cannot see customized email on same page when creating tea time
1. Cannot change if you want to send customized reminder email after tea time is created
1. Can only customize the T-48 hr email
1. Cannot preview customized email