### PR TITLE
Fix copy and subject of pretea nudge for hosts

### DIFF
--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -7,7 +7,8 @@ class HostMailer < ActionMailer::Base
       "#{u.name} (#{u.phone_number})"
     end.join(", ")
 
-    mail(to: @tea_time.host.email) do |format|
+    mail(to: @tea_time.host.email,
+         subject: "Remind your attendees about tea time!") do |format|
       format.text
       format.html
     end

--- a/app/views/host_mailer/pre_tea_time_nudge.markerb
+++ b/app/views/host_mailer/pre_tea_time_nudge.markerb
@@ -6,9 +6,9 @@
 
   <% if @shareable_num_string %>
 
-    Some of these folks are super trusting and gave you their numbers. Be cool and use them appropriately. Texting them the day of tea time makes it easier for them to remember you're not all that strange (and that helps ensure they show up with good spirits!)
+  Some of these folks are super trusting and gave you their numbers. Be cool and use them appropriately. Texting them the day of tea time makes it easier for them to remember you're not all that strange (and that helps ensure they show up with good spirits!)
 
-    <%= @shareable_num_string %>
+  <%= @shareable_num_string %>
 
   <% end %>
 

--- a/app/views/host_mailer/pre_tea_time_nudge.markerb
+++ b/app/views/host_mailer/pre_tea_time_nudge.markerb
@@ -1,25 +1,29 @@
-<% if @tea_time.attendees.present? %>?
-  Hey! Your tea time is on Thursday at 7:00pm. Now would be a good time to email your attendees to confirm they're in, offer a chance for them to cancel if needed, and share whatever other info you might need to. Try to do this today so they have sufficient notice.
+<% if @tea_time.attendees.present? %>
+  Hey! Your tea time is on <%= @tea_time.day %> at <%= @tea_time.start_time.strftime("%-l:%M%P") %>. Now would be a good time to email your attendees to confirm they're in, offer a chance for them to cancel if needed, and share whatever other info you might need to. Try to do this today so they have sufficient notice.
 
   <%= @tea_time.attendees.map(&:name).join(", ") %>  
   <%= @tea_time.attendees.map(&:email).join(", ") %>
 
-  Some of these folks are super trusting and gave you their numbers. Be cool and use them appropriately. Texting them the day of tea time makes it easier for them to remember you're not all that strange (and that helps ensure they show up with good spirits!)
+  <% if @shareable_num_string %>
 
-<% if @shareable_num_string %>
-<%= @shareable_num_string %>
-<% end %>
+    Some of these folks are super trusting and gave you their numbers. Be cool and use them appropriately. Texting them the day of tea time makes it easier for them to remember you're not all that strange (and that helps ensure they show up with good spirits!)
+
+    <%= @shareable_num_string %>
+
+  <% end %>
 
   In the case you include any info in the email that's not on the site, update the info there for the attendees that sign up after you send your email. <%= link_to "You can do that here", edit_tea_time_url(@tea_time) %>.
+
 <% else %>
-  Hey! Your tea time is on Thursday at 7:00pm. You don't have any attendees yet :(, but check the site sometime tomorrow and be sure to reach out to the attendees that sign up and confirm their attendance. Also, make sure the info on the site is everything an attendee needs to find you. <%= link_to "Click here to make edits", edit_tea_time_url(@tea_time) %>.
+
+  Hey! Your tea time is on <%= @tea_time.day %> at <%= @tea_time.start_time.strftime("%-l:%M%P") %>. You don't have any attendees yet :(, but check the site sometime tomorrow and be sure to reach out to the attendees that sign up and confirm their attendance. Also, make sure the info on the site is everything an attendee needs to find you. <%= link_to "Click here to make edits", edit_tea_time_url(@tea_time) %>.
 
 <% end %>
 
-Bleep bleep bloop,
+Bleep bleep bloop,  
 The Robots at Tea With Strangers
 
---
+---
 
 <em>
 Current details of your tea time:
@@ -27,5 +31,5 @@ Current details of your tea time:
 When? <%= @tea_time.friendly_time %>  
 Where? <%= @tea_time.location %>  
 Notes: <%= @tea_time.notes.blank? ? "[None]" : @tea_time.notes %>  
-Attendance: <%= @tea_time.attendances.pending.count %> attendees, <%= @tea_time.attendances.flake.count %>, <%= @tea_time.attendances.waitlisted.count %> waitlists
+Attendance: <%= @tea_time.attendances.pending.count %> attendees, <%= @tea_time.attendances.flake.count %> cancelations, <%= @tea_time.attendances.waitlisted.count %> waitlists
 </em>


### PR DESCRIPTION
Addresses all comments in https://github.com/TeaWithStrangers/tws-on-rails/pull/617

TO DO: 

* [x] Confirm that this email is not being queued up upon tea time creation, as that'll ensure that hosts will always get the version for no attendees
  * @mehulkar mailcatcher indicates that this email is queued when the tea time is created, but I'm not sure if the content is populated based on the tea time's attendance status at the time of email being sent or if it's taking in the attendance status at creation...in which case it's always no attendees