### PR TITLE
Remove soft deletes from attendance model.

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,7 +1,4 @@
 class Attendance < ActiveRecord::Base
-  # Attendances should never be deleted, only soft-deleted
-  acts_as_paranoid
-
   belongs_to :user
   belongs_to :tea_time, touch: true
   enum :status => [:pending, :flake, :no_show, :present, :waiting_list, :cancelled]


### PR DESCRIPTION
There is no UI or API endpoint to delete attendances.
The only time we delete attendances is manually through console.

ActiveRecord uniquness validations seems to not work with soft deletes,
since the scope deleted_at scope does not get applied.
This means that if an attendance record is soft deleted,
and I attempt to create another identical record (with
the same user_id), the uniqueness validations will fail.

Further, if two attendance records with the same user_id
exist, one of them will ALWAYS be invalid, meaning that
we can never apply any updates to it (because .save will
fail).

This is why marking attendances was failing for some tea_times.
It had duplicate attendance records which had been soft deleted.

Fixes #634 

In addition to this PR, I am also running this in the production db console:

```ruby
Attendance.unscoped.where.not(deleted_at: nil).count
#=> 4
Attendance.unscoped.where.not(deleted_at: nil).destroy_all
```