### PR TITLE
Non-host Users still have a show_host page

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -6,6 +6,12 @@ class HostsController < ApplicationController
   def show
     @city = City.for_code(params[:id])
     @host = User.find(params[:host_id])
+    if !@host.host?
+      return redirect_to @city,
+                  alert: "Uh-oh!
+                  We couldn't find who you were looking for. Try another one of
+                  our wonderful hosts?"
+    end
     respond_to do |format|
       format.html { render layout: !request.xhr? }
       format.json { render json: @host }


### PR DESCRIPTION
This leaks the first/last name of the affected users if you iterate through all
IDs and is also a confusing experience if navigated to by mistake or typo, as
they have no host description, tea times, etc.

Fixes this and redirects them back to the appropriate city page