### PR TITLE
Use smaller city images for the overview page

### DIFF
--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -15,7 +15,7 @@
         <div class="cities-list current-cities-container" data-city-type='active'>
           <% @active_cities.each do |city| %>
             <div class="city">
-              <div class="city-image" style="background-image: url('<%= city.header_bg %>');">
+              <div class="city-image" style="background-image: url('<%= city.header_bg(:small) %>');">
                 <h2 class=" city-name">
                   <%= link_to city.name, city_path(city), class: 'background-filter' %>
                   <%= link_to city.name, city_path(city), class: 'city-name' %>
@@ -30,7 +30,7 @@
         <div class="cities-list current-cities-container" data-city-type='active'>
           <% @upcoming_cities.each do |city| %>
             <div class="city">
-              <div class="city-image" style="background-image: url('<%= city.header_bg %>');">
+              <div class="city-image" style="background-image: url('<%= city.header_bg(:small) %>');">
                 <h2 class=" city-name">
                   <%= link_to city.name, city_path(city), class: 'background-filter' %>
                   <%= link_to city.name, city_path(city), class: 'city-name' %>


### PR DESCRIPTION
This should shrink the size of the city page dramatically, no longer loading 10mb+ of images (sorry mobile users!)