### PR TITLE
Permit future tea times only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :development, :test do
   gem 'rails-observers'
   gem 'shoulda-matchers', require: false
   gem 'coveralls', require: false
+  gem 'timecop'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,7 @@ GEM
     time_zone_ext (0.0.3)
       activesupport
       tzinfo
+    timecop (0.8.1)
     timers (4.0.1)
       hitimes
     tins (1.5.1)
@@ -376,12 +377,10 @@ DEPENDENCIES
   spring
   therubyracer (~> 0.12)
   time_zone_ext
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   underscore-rails
   unicorn
   unicorn-rails
   will_paginate
-
-BUNDLED WITH
-   1.10.5

--- a/app/controllers/tea_times_controller.rb
+++ b/app/controllers/tea_times_controller.rb
@@ -42,7 +42,7 @@ class TeaTimesController < ApplicationController
     if @tea_time.save
       redirect_to profile_path, notice: 'Tea time was successfully created.'
     else
-      render :new
+      redirect_to :back, notice: "Invalid submission: #{@tea_time.errors.full_messages.join(', ')}"
     end
   end
 

--- a/app/models/tea_time.rb
+++ b/app/models/tea_time.rb
@@ -84,7 +84,7 @@ class TeaTime < ActiveRecord::Base
 
   def has_not_past?
     if Time.now >= self.start_time
-      errors.add(:start_time, 'Must be a future time')
+      errors.add(:start_time, 'must be a future time')
       false
     else
       true

--- a/app/models/tea_time.rb
+++ b/app/models/tea_time.rb
@@ -4,7 +4,7 @@ class TeaTime < ActiveRecord::Base
 
   validates_presence_of :host, :start_time, :city, :duration
   validate :attendance_marked?, if: :occurred?
-
+  validate :not_past
   belongs_to :city
   belongs_to :host, :class_name => 'User', :foreign_key => 'user_id'
 
@@ -79,6 +79,15 @@ class TeaTime < ActiveRecord::Base
       write_attribute(:start_time, reparse_time_in_tz(time))
     else
       super
+    end
+  end
+
+  def not_past
+    if Time.now >= self.start_time
+      errors.add(:start_time, 'Must be a future time')
+      false
+    else
+      true
     end
   end
 

--- a/app/models/tea_time.rb
+++ b/app/models/tea_time.rb
@@ -4,7 +4,7 @@ class TeaTime < ActiveRecord::Base
 
   validates_presence_of :host, :start_time, :city, :duration
   validate :attendance_marked?, if: :occurred?
-  validate :not_past
+  validate :has_not_past?
   belongs_to :city
   belongs_to :host, :class_name => 'User', :foreign_key => 'user_id'
 
@@ -82,7 +82,7 @@ class TeaTime < ActiveRecord::Base
     end
   end
 
-  def not_past
+  def has_not_past?
     if Time.now >= self.start_time
       errors.add(:start_time, 'Must be a future time')
       false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'capybara/rails'
 require 'capybara/rspec'
 require "cancan/matchers"
 require 'shoulda/matchers'
+require 'factory_girl_rails'
 
 #Coveralls Test Coverage
 require 'coveralls'


### PR DESCRIPTION
Hosts were able to create tea times with past dates and times. This resulted in the tea time being posted directly to the host's history, despite the event having never occurred. This validation prevents these tea times from being saved.