### PR TITLE
don't send host reminder emails if tea time is cancelled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,3 @@ DEPENDENCIES
   unicorn
   unicorn-rails
   will_paginate
-
-BUNDLED WITH
-   1.10.5

--- a/app/mailers/attendance_mailer.rb
+++ b/app/mailers/attendance_mailer.rb
@@ -122,8 +122,9 @@ class AttendanceMailer < ActionMailer::Base
 
   def mark_attendance_reminder(tea_time_id)
     @tea_time = TeaTime.find(tea_time_id)
-    @host = @tea_time.host
+    cancel_delivery if @tea_time.cancelled?
 
+    @host = @tea_time.host
     mail(to: @host.friendly_email,
          subject: "Mark attendance for your tea time!") do |format|
       format.text

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -3,6 +3,8 @@ class HostMailer < ActionMailer::Base
 
   def pre_tea_time_nudge(tea_time_id)
     @tea_time = TeaTime.find_by(id: tea_time_id)
+    cancel_delivery if @tea_time.cancelled?
+
     @shareable_num_string = @tea_time.attendees_with_shareable_phone_numbers.map do |u|
       "#{u.name} (#{u.phone_number})"
     end.join(", ")

--- a/spec/mailers/attendance_mailer_spec.rb
+++ b/spec/mailers/attendance_mailer_spec.rb
@@ -74,6 +74,19 @@ describe AttendanceMailer do
     end
   end
 
+  describe '#mark_attendance_reminder' do
+    let(:tt) { create(:tea_time, followup_status: :cancelled) }
+    let(:attendance) { create(:attendance, tea_time: tt) }
+    let(:mail) {
+      AttendanceMailer.mark_attendance_reminder(attendance.id)
+    }
+
+    it "should not send if tea time was cancelled" do
+      mail.deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+  end
+
   #TODO: This is really a test of .flake! not the message itself. Move to
   #attendance_spec when possible
   describe '#flake' do

--- a/spec/mailers/host_mailer_spec.rb
+++ b/spec/mailers/host_mailer_spec.rb
@@ -11,8 +11,21 @@ describe HostMailer do
       create(:tea_time, user_id: host.id).id
     end
 
+    let(:cancelled_tea_time) do
+      create(:tea_time, user_id: host.id, followup_status: :cancelled)
+    end
+
     let(:mail) do
       described_class.pre_tea_time_nudge(tea_time_id)
+    end
+
+    let(:cancelled_mail) do
+      described_class.pre_tea_time_nudge(cancelled_tea_time.id)
+    end
+
+    it 'should not send for cancelled tea time' do
+      cancelled_mail.deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
     end
 
     it 'should be from the default address' do


### PR DESCRIPTION
Addresses 1. (first and third checkboxes) of https://github.com/TeaWithStrangers/tws-on-rails/issues/676. It's unclear whether the 2nd checkbox is still a problem, [this job](https://github.com/TeaWithStrangers/tws-on-rails/blob/master/app/jobs/tea_time_followup_notifier.rb) already seems to be blocking those emails if the tea time was cancelled. @nick, any insight?

@nickbarnwell 
