### PR TITLE
group hosts by activity level

### DIFF
--- a/app/jobs/refresh_host_activity_status.rb
+++ b/app/jobs/refresh_host_activity_status.rb
@@ -1,0 +1,52 @@
+class RefreshHostActivityStatus
+  ACTIVE_EXPIRATION = 30.days
+  MILD_LEGACY = {
+    :tea_time_max => 5,
+    :expiration => 2.months,
+  }
+  STRONG_LEGACY = {
+    :tea_time_max => 10,
+    :expiration => 3.months,
+  }
+
+  def self.run
+    User.hosts.each do |user|
+      host_detail = user.host_detail
+      # update or create a host_detail for the host
+      new_status = find_new_status(user)
+      if host_detail
+        if new_status != host_detail.activity_status
+          host_detail.update(:activity_status => new_status)
+        end
+      else
+        detail = user.build_host_detail(:activity_status => new_status)
+        detail.save!
+      end
+    end
+  end
+
+  def self.find_new_status(user)
+    tea_times = user.tea_times.order('start_time asc').to_a
+    if tea_times.empty?
+      # INACTIVE
+      new_status = HostDetail::ACTIVITY_STATUS_INACTIVE
+    elsif tea_times.last.start_time > (Time.now - ACTIVE_EXPIRATION)
+      # ACTIVE
+      new_status = HostDetail::ACTIVITY_STATUS_ACTIVE
+    else
+      if legacy_expired?(MILD_LEGACY, tea_times) || legacy_expired?(STRONG_LEGACY, tea_times)
+        # INACTIVE (legacy expired)
+        new_status = HostDetail::ACTIVITY_STATUS_INACTIVE
+      else
+        # LEGACY
+        new_status = HostDetail::ACTIVITY_STATUS_LEGACY
+      end
+    end
+  end
+
+  def self.legacy_expired?(legacy_type, tea_times)
+    expiration_cutoff = Time.now - ACTIVE_EXPIRATION - legacy_type[:expiration]
+    tea_times.count <= legacy_type[:tea_time_max] &&
+      tea_times.last.start_time < expiration_cutoff
+  end
+end

--- a/app/models/host_detail.rb
+++ b/app/models/host_detail.rb
@@ -1,0 +1,7 @@
+class HostDetail < ActiveRecord::Base
+  belongs_to :user
+
+  ACTIVITY_STATUS_INACTIVE = 0
+  ACTIVITY_STATUS_ACTIVE = 1
+  ACTIVITY_STATUS_LEGACY = 2
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
 
   has_many :tea_times
   has_many :attendances
+  has_one :host_detail
   has_one :email_reminder, as: :remindable
   belongs_to :home_city, class_name: 'City', counter_cache: true
   has_attached_file :avatar, styles: { medium: "300x300", thumb: "100x100", landscape: "500"}, default_url: "/assets/missing.jpg"

--- a/spec/factories/host_details.rb
+++ b/spec/factories/host_details.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  factory :host_detail, class: 'HostDetail' do
+    association :user, factory: [:user, :host]
+    activity_status 0
+
+    trait :inactive do
+    end
+
+    trait :active do
+      activity_status 1
+    end
+
+    trait :legacy do
+      activity_status 2
+    end
+  end
+end

--- a/spec/jobs/refresh_host_activity_status_spec.rb
+++ b/spec/jobs/refresh_host_activity_status_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper.rb'
+
+describe RefreshHostActivityStatus do
+  let!(:host) { create(:user, :host) }
+  let(:expiration) { RefreshHostActivityStatus::ACTIVE_EXPIRATION }
+  let(:mild_expiration) { RefreshHostActivityStatus::MILD_LEGACY[:expiration] }
+  let(:strong_expiration) { RefreshHostActivityStatus::STRONG_LEGACY[:expiration] }
+  let(:mild_max) { RefreshHostActivityStatus::MILD_LEGACY[:tea_time_max] }
+  let(:strong_max) { RefreshHostActivityStatus::STRONG_LEGACY[:tea_time_max] }
+
+  context 'with an active host' do
+    let!(:tea_time) { create(:tea_time, :host => host, :start_time => Time.now - 1.day) }
+
+    it 'works with no existing host detail' do
+      RefreshHostActivityStatus.run
+      expect(host.host_detail.activity_status).to eql HostDetail::ACTIVITY_STATUS_ACTIVE
+    end
+
+    it 'works with an existing host detail' do
+      create(:host_detail, :inactive, :user => host)
+      RefreshHostActivityStatus.run
+      expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_ACTIVE
+    end
+  end
+
+  context 'with an inactive host' do
+    it 'works with no existing host detail' do
+      RefreshHostActivityStatus.run
+      expect(host.host_detail.activity_status).to eql HostDetail::ACTIVITY_STATUS_INACTIVE
+    end
+
+    it 'works with an existing host detail' do
+      create(:host_detail, :active, :user => host)
+      RefreshHostActivityStatus.run
+      expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_INACTIVE
+    end
+  end
+
+  context 'with a legacy host' do
+    let!(:tea_time) do
+      create(
+        :tea_time,
+        :host => host,
+        :start_time => Time.now - expiration - 1.day
+      )
+    end
+
+    it 'works with no existing host detail' do
+      RefreshHostActivityStatus.run
+      expect(host.host_detail.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+    end
+
+    it 'works with an existing host detail' do
+      create(:host_detail, :active, :user => host)
+      RefreshHostActivityStatus.run
+      expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+    end
+  end
+
+  context 'with a host that has been legacy for a while' do
+    context 'and is mild legacy' do
+      let!(:tea_time) do
+        create(
+          :tea_time,
+          :host => host,
+          :start_time => Time.now - expiration - mild_expiration - 1.day,
+        )
+      end
+      it 'works with no existing host detail' do
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.activity_status).to eql HostDetail::ACTIVITY_STATUS_INACTIVE
+      end
+
+      it 'works with an existing host detail' do
+        create(:host_detail, :active, :user => host)
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_INACTIVE
+      end
+
+      it 'does not change if tea time is too recent' do
+        tea_time.start_time = Time.now - expiration - mild_expiration + 1.day
+        tea_time.save!
+        create(:host_detail, :legacy, :user => host)
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+      end
+    end
+
+    context 'and is strong legacy' do
+      it 'works with no existing host detail' do
+        (mild_max + 1).times do
+          create(
+            :tea_time,
+            :host => host,
+            :start_time => Time.now - expiration - strong_expiration - 1.day,
+          )
+        end
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.activity_status).to eql HostDetail::ACTIVITY_STATUS_INACTIVE
+      end
+
+      it 'works with an existing host detail' do
+        (mild_max + 1).times do
+          create(
+            :tea_time,
+            :host => host,
+            :start_time => Time.now - expiration - strong_expiration - 1.day,
+          )
+        end
+        create(:host_detail, :active, :user => host)
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_INACTIVE
+      end
+
+      it 'does not change if tea time is too recent' do
+        (mild_max + 1).times do
+          create(
+            :tea_time,
+            :host => host,
+            :start_time => Time.now - expiration - strong_expiration + 1.day,
+          )
+        end
+        create(:host_detail, :legacy, :user => host)
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+      end
+    end
+
+    context 'and is permanent legacy' do
+      it 'does nothing with no existing host detail' do
+        (strong_max + 1).times do
+          create(
+            :tea_time,
+            :host => host,
+            :start_time => Time.now - expiration - strong_expiration - 1.day,
+          )
+        end
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+      end
+
+      it 'does nothing with an existing host detail' do
+        (strong_max + 1).times do
+          create(
+            :tea_time,
+            :host => host,
+            :start_time => Time.now - expiration - strong_expiration - 1.day,
+          )
+        end
+        create(:host_detail, :active, :user => host)
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+      end
+
+      it 'does not change if tea time is recent' do
+        (strong_max + 1).times do
+          create(
+            :tea_time,
+            :host => host,
+            :start_time => Time.now - expiration - strong_expiration + 1.day,
+          )
+        end
+        create(:host_detail, :legacy, :user => host)
+        RefreshHostActivityStatus.run
+        expect(host.host_detail.reload.activity_status).to eql HostDetail::ACTIVITY_STATUS_LEGACY
+      end
+    end
+  end
+end

--- a/spec/mailers/attendance_mailer_spec.rb
+++ b/spec/mailers/attendance_mailer_spec.rb
@@ -76,9 +76,8 @@ describe AttendanceMailer do
 
   describe '#mark_attendance_reminder' do
     let(:tt) { create(:tea_time, followup_status: :cancelled) }
-    let(:attendance) { create(:attendance, tea_time: tt) }
     let(:mail) {
-      AttendanceMailer.mark_attendance_reminder(attendance.id)
+      AttendanceMailer.mark_attendance_reminder(tt.id)
     }
 
     it "should not send if tea time was cancelled" do


### PR DESCRIPTION
Job to save all hosts' activity status.

Not included (yet): cron job to actually run it, google spreadsheets exporting, front-end display
(specs will fail until i run [this](https://github.com/TeaWithStrangers/tws-on-rails/pull/689) migration
@nickbarnwell @ankitshah811 