### PR TITLE
Fix Intermittently Failing Attendance Mailer Specs

### DIFF
--- a/spec/mailers/attendance_mailer_spec.rb
+++ b/spec/mailers/attendance_mailer_spec.rb
@@ -76,9 +76,8 @@ describe AttendanceMailer do
 
   describe '#mark_attendance_reminder' do
     let(:tt) { create(:tea_time, followup_status: :cancelled) }
-    let(:attendance) { create(:attendance, tea_time: tt) }
     let(:mail) {
-      AttendanceMailer.mark_attendance_reminder(attendance.id)
+      AttendanceMailer.mark_attendance_reminder(tt.id)
     }
 
     it "should not send if tea time was cancelled" do


### PR DESCRIPTION
`mark_attendance_mailer` expects a Tea Time ID, not an Attendance object. The
test was being passed an Attendance ID.  This just so happened to work most of
the time because there are TTs littering the DB from prior tests. This does not
work when mailer specs are run earlier, and so it failed intermittently under
CI.