### PR TITLE
Rename activity enum to match column name

### DIFF
--- a/app/jobs/refresh_host_activity_status.rb
+++ b/app/jobs/refresh_host_activity_status.rb
@@ -31,17 +31,17 @@ class RefreshHostActivityStatus
     tea_times = user.tea_times.order('start_time asc').to_a
     if tea_times.empty?
       # INACTIVE
-      new_status = HostDetail::statuses[:inactive]
+      new_status = :inactive
     elsif tea_times.last.start_time > (Time.now - ACTIVE_EXPIRATION)
       # ACTIVE
-      new_status = HostDetail::statuses[:active]
+      new_status = :active
     else
       if legacy_expired?(MILD_LEGACY, tea_times) || legacy_expired?(STRONG_LEGACY, tea_times)
         # INACTIVE (legacy expired)
-        new_status = HostDetail::statuses[:inactive]
+        new_status = :inactive
       else
         # LEGACY
-        new_status = HostDetail::statuses[:legacy]
+        new_status = :legacy
       end
     end
   end

--- a/app/models/host_detail.rb
+++ b/app/models/host_detail.rb
@@ -1,4 +1,4 @@
 class HostDetail < ActiveRecord::Base
   belongs_to :user
-  enum status: { inactive: 0, active: 1, legacy: 2 }
+  enum activity_status: { inactive: 0, active: 1, legacy: 2 }
 end

--- a/spec/jobs/refresh_host_activity_status_spec.rb
+++ b/spec/jobs/refresh_host_activity_status_spec.rb
@@ -13,26 +13,26 @@ describe RefreshHostActivityStatus do
 
     it 'works with no existing host detail' do
       RefreshHostActivityStatus.run
-      expect(host.host_detail.activity_status).to eql HostDetail::statuses[:active]
+      expect(host.host_detail.active?).to eql true
     end
 
     it 'works with an existing host detail' do
       create(:host_detail, :inactive, :user => host)
       RefreshHostActivityStatus.run
-      expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:active]
+      expect(host.host_detail.reload.activity_status).to eql "active"
     end
   end
 
   context 'with an inactive host' do
     it 'works with no existing host detail' do
       RefreshHostActivityStatus.run
-      expect(host.host_detail.activity_status).to eql HostDetail::statuses[:inactive]
+      expect(host.host_detail.activity_status).to eql "inactive"
     end
 
     it 'works with an existing host detail' do
       create(:host_detail, :active, :user => host)
       RefreshHostActivityStatus.run
-      expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:inactive]
+      expect(host.host_detail.reload.activity_status).to eql "inactive"
     end
   end
 
@@ -47,13 +47,13 @@ describe RefreshHostActivityStatus do
 
     it 'works with no existing host detail' do
       RefreshHostActivityStatus.run
-      expect(host.host_detail.activity_status).to eql HostDetail::statuses[:legacy]
+      expect(host.host_detail.activity_status).to eql "legacy"
     end
 
     it 'works with an existing host detail' do
       create(:host_detail, :active, :user => host)
       RefreshHostActivityStatus.run
-      expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:legacy]
+      expect(host.host_detail.reload.activity_status).to eql "legacy"
     end
   end
 
@@ -68,13 +68,13 @@ describe RefreshHostActivityStatus do
       end
       it 'works with no existing host detail' do
         RefreshHostActivityStatus.run
-        expect(host.host_detail.activity_status).to eql HostDetail::statuses[:inactive]
+        expect(host.host_detail.activity_status).to eql "inactive"
       end
 
       it 'works with an existing host detail' do
         create(:host_detail, :active, :user => host)
         RefreshHostActivityStatus.run
-        expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:inactive]
+        expect(host.host_detail.reload.activity_status).to eql "inactive"
       end
 
       it 'does not change if tea time is too recent' do
@@ -82,7 +82,7 @@ describe RefreshHostActivityStatus do
         tea_time.save!
         create(:host_detail, :legacy, :user => host)
         RefreshHostActivityStatus.run
-        expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:legacy]
+        expect(host.host_detail.reload.activity_status).to eql "legacy"
       end
     end
 
@@ -96,7 +96,7 @@ describe RefreshHostActivityStatus do
           )
         end
         RefreshHostActivityStatus.run
-        expect(host.host_detail.activity_status).to eql HostDetail::statuses[:inactive]
+        expect(host.host_detail.activity_status).to eql "inactive"
       end
 
       it 'works with an existing host detail' do
@@ -109,7 +109,7 @@ describe RefreshHostActivityStatus do
         end
         create(:host_detail, :active, :user => host)
         RefreshHostActivityStatus.run
-        expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:inactive]
+        expect(host.host_detail.reload.activity_status).to eql "inactive"
       end
 
       it 'does not change if tea time is too recent' do
@@ -122,7 +122,7 @@ describe RefreshHostActivityStatus do
         end
         create(:host_detail, :legacy, :user => host)
         RefreshHostActivityStatus.run
-        expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:legacy]
+        expect(host.host_detail.reload.activity_status).to eql "legacy"
       end
     end
 
@@ -136,7 +136,7 @@ describe RefreshHostActivityStatus do
           )
         end
         RefreshHostActivityStatus.run
-        expect(host.host_detail.activity_status).to eql HostDetail::statuses[:legacy]
+        expect(host.host_detail.activity_status).to eql "legacy"
       end
 
       it 'does nothing with an existing host detail' do
@@ -149,7 +149,7 @@ describe RefreshHostActivityStatus do
         end
         create(:host_detail, :active, :user => host)
         RefreshHostActivityStatus.run
-        expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:legacy]
+        expect(host.host_detail.reload.activity_status).to eql "legacy"
       end
 
       it 'does not change if tea time is recent' do
@@ -162,7 +162,7 @@ describe RefreshHostActivityStatus do
         end
         create(:host_detail, :legacy, :user => host)
         RefreshHostActivityStatus.run
-        expect(host.host_detail.reload.activity_status).to eql HostDetail::statuses[:legacy]
+        expect(host.host_detail.reload.activity_status).to eql "legacy"
       end
     end
   end


### PR DESCRIPTION
Original enum change did not properly test that status was updated, and job was
setting the value forcibly rather than going through the setters. This makes
using enum methods work properly
