### PR TITLE
Styling legacy hosts and adjusting city page copy

### DIFF
--- a/app/assets/stylesheets/cities/_index.scss
+++ b/app/assets/stylesheets/cities/_index.scss
@@ -210,14 +210,14 @@ h3.cities-list-header {
 }
 
 .city-info {
-  h2.section-header {
+  .section-header {
     margin-bottom: $base-font-size;
   }
 
   .section {
     margin-bottom: $base-font-size*2;
     clear: both;
-    overflow: auto;
+    overflow: visible;
 
     &.line-divide {
       padding-bottom: $base-font-size*2;

--- a/app/assets/stylesheets/components/_hosts.scss
+++ b/app/assets/stylesheets/components/_hosts.scss
@@ -24,6 +24,10 @@ hosts across the website.
 			position: relative;
 			margin-bottom: 2em;
 
+      &.no-photo {
+        padding-top: 0em;
+      }
+
 			h3 {
 				padding: 0.75em 0;
 

--- a/app/assets/stylesheets/components/_hosts.scss
+++ b/app/assets/stylesheets/components/_hosts.scss
@@ -5,7 +5,7 @@ hosts across the website.
 
 */
 
-.host-grid-container {
+.active-host-container {
 	margin-top: 1em;
 	margin-bottom: 2em;
 	clear: both;
@@ -23,10 +23,6 @@ hosts across the website.
 			padding: 0.5em 0.5em 0 0.5em;
 			position: relative;
 			margin-bottom: 2em;
-
-      &.no-photo {
-        padding-top: 0em;
-      }
 
 			h3 {
 				padding: 0.75em 0;
@@ -81,4 +77,37 @@ hosts across the website.
 		}
 	}
 	
+}
+
+.legacy-hosts {
+  h3 {
+    color: $tws-orange;
+    position: relative;
+  }
+  .legacy-host-container {
+    margin-top: 1em;
+    margin-bottom: 2em;
+    clear: both;
+    overflow: auto;
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow: auto;
+    text-align: center;
+    li {
+      display: inline-block;
+      padding: 0 0.5em;
+      h4:after {
+        content: '•';
+        position: relative;
+        left: 0.5em;
+        color: $tws-yellow;
+      }
+      &:last-child h4:after {
+        content: '';
+      }
+    }
+  }
 }

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -49,8 +49,14 @@ class City < ActiveRecord::Base
   end
 
   def hosts
-    hosts = proxy_cities.inject([]) {|lst, c| lst + c.hosts}
     User.hosts.where(home_city: [self] + proxy_cities)
+  end
+  
+  def hosts_by_status
+    users = User.hosts.where(home_city: self.id).includes(:host_detail).group_by {|h| h.host_detail.activity_status }
+    # Return empty array if there are no users in that group
+    users.default = []
+    users
   end
 
   def timezone=(tz)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-
   has_many :tea_times
   has_many :attendances
   has_one :host_detail
@@ -21,6 +20,7 @@ class User < ActiveRecord::Base
   validates_with Validators::TwitterHandleValidator
 
   before_destroy :flake_future
+  after_create :generate_host_detail
 
   bitmask :roles, :as => [:host, :admin], :null => false
   alias_method :role?, :roles?
@@ -83,6 +83,10 @@ class User < ActiveRecord::Base
     attendances_for(TeaTime.future).each do |a|
       a.flake!(email: false)
     end
+  end
+
+  def generate_host_detail
+    HostDetail.create(user: self)
   end
 
   def waitlist

--- a/app/views/cities/_host_headshots.html.erb
+++ b/app/views/cities/_host_headshots.html.erb
@@ -1,40 +1,63 @@
 <% count = hosts.count  %>
 <% many_hosts = hosts.count > 2 %>
+
 <div class="host-grid-partial">
-  <div class="section host-intro">
-    <h2 class="section-header">
-      Get to know the hosts
-    </h2>
-    <p>
-      The host community is full of folks that generally love 
-      good conversations, bringing people together, and open 
-      minds. Like yourself, each of them has an incredible story 
-      that brought them to where they are right now. 
-    </p>
+  <div class="active-hosts">
+    <div class="section host-intro">
+      <h2 class="section-header">
+        The Host Community is full of amazing stories.
+      </h2>
+      <p>
+        How else would someone end up regularly 
+        bringing strangers together for conversations? 
+        Before each of them were invited to community, 
+        they were attendees that fed their tea times 
+        with their questions, open-mindedness, and 
+        presence.
+      </p>
+    </div>
+    <div class="active-host-container">
+      <ul class="host-headshots">
+        <% hosts["active"].each do |host| %>
+          <li class="host-container">
+            <a href="<%= host_city_path(@city, host) %>">
+              <div class="host-avatar ">
+                <div class="avatar" style="background-image: url('<%= host.avatar.url(:medium) %>');"></div>
+              </div>
+              <h3 class="center capitalize">
+                <%= link_to(host.name || "No Name :(", host_city_path(@city, host) ) %>
+              </h3>
+            </a>
+          </li>
+        <%end %>
+      </ul> 
+    </div>
   </div>
-  <div class="host-grid-container">
-    <ul class="host-headshots">
-      <% hosts["active"].each do |host| %>
-        <li class="host-container">
-          <a href="<%= host_city_path(@city, host) %>">
-            <div class="host-avatar ">
-              <div class="avatar" style="background-image: url('<%= host.avatar.url(:medium) %>');"></div>
-            </div>
-            <h3 class="center capitalize">
-              <%= link_to(host.name || "No Name :(", host_city_path(@city, host) ) %>
-            </h5>
-          </a>
-        </li>
-      <%end %>
-      <% hosts["legacy"].each do |host| %>
-        <li class="host-container no-photo">
-          <a href="<%= host_city_path(@city, host) %>">
-            <h3 class="center capitalize" >
-              <%= link_to(host.name || "No Name :(", host_city_path(@city, host) ) %>
-            </h5>
-          </a>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+
+  <% if hosts["legacy"].count > 0 %>
+    <div class="legacy-hosts">
+      <div class="section host-intro">
+        <h3 class="section-header">
+          Hosts we've missed!
+        </h3>
+        <p>
+          Every host in the community has played a huge role in making this movement come to life. You might not have seen tea times from these hosts in a bit, but without them, Tea With Strangers in <%= "#{@city.name}"%> wouldn't be where it is today.
+        </p>
+      </div>
+      <div class="legacy-host-container">
+        <ul class="host-legacy">
+          <% hosts["legacy"].each do |host| %>
+            <li class="host-container no-photo">
+              <a href="<%= host_city_path(@city, host) %>">
+                <h4 class="center" >
+                  <%= link_to(host.name || "🤔", host_city_path(@city, host) ) %>
+                </h4>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
 </div>

--- a/app/views/cities/_host_headshots.html.erb
+++ b/app/views/cities/_host_headshots.html.erb
@@ -14,13 +14,22 @@
   </div>
   <div class="host-grid-container">
     <ul class="host-headshots">
-      <% hosts.each do |host| %>
+      <% hosts["active"].each do |host| %>
         <li class="host-container">
           <a href="<%= host_city_path(@city, host) %>">
             <div class="host-avatar ">
               <div class="avatar" style="background-image: url('<%= host.avatar.url(:medium) %>');"></div>
             </div>
             <h3 class="center capitalize">
+              <%= link_to(host.name || "No Name :(", host_city_path(@city, host) ) %>
+            </h5>
+          </a>
+        </li>
+      <%end %>
+      <% hosts["legacy"].each do |host| %>
+        <li class="host-container no-photo">
+          <a href="<%= host_city_path(@city, host) %>">
+            <h3 class="center capitalize" >
               <%= link_to(host.name || "No Name :(", host_city_path(@city, host) ) %>
             </h5>
           </a>

--- a/app/views/cities/show/_active.html.erb
+++ b/app/views/cities/show/_active.html.erb
@@ -26,5 +26,5 @@
 </div>
 
 <div class="section host-grid">
-	<%= render partial: 'host_headshots', locals: {hosts: @city.hosts} %>
+	<%= render partial: 'host_headshots', locals: {hosts: @city.hosts_by_status} %>
 </div>

--- a/app/views/cities/show/_active.html.erb
+++ b/app/views/cities/show/_active.html.erb
@@ -2,17 +2,17 @@
 	<% tts = @city.tea_times.future_until(2.weeks.from_now) %>
 	<% if tts.count < 1 %>
 		<h2 class="section-header">
-			There aren't any upcoming tea times!
+			There aren't any upcoming Tea Times!
 		</h2>
 		<p>
 			We're working on getting some more up on the board! Sorry for any disappointment, but if you'd like, <a href="mailto:ankit@teawithstrangers.com?Subject=More%20tea%20times%20please!%21" target="_blank">shoot Ankit, the founder of TWS, an email</a> that he'll screenshot and send to the hosts to give 'em some inspiration.
 		</p>
 	<% else %>
 		<h2 class="section-header">
-			Join for a tea time in the next two weeks!
+			Tea Time is a conversation between a few people who know nothing about each other.
 		</h2>
 		<p>
-			Every tea time is brought together by someone in our host community that gets it. Each of them was brought on by hosts before them. They’re all awesome, but you can get to know them by checking out their profiles.	
+			You'll never leave without questions, new perspectives, and the reminder that we're far more the same than we are different.  
 		</p>
 	<% end %>
 	<%= render partial: 'cities/show/set_city' %>


### PR DESCRIPTION
This is now what an active city page will look like. I forced the 'legacy' status on the hosts in the bottom section, so not certain what conditions are to become 'legacy'

The legacy section also only shows up if there are any legacy hosts. 

![new york city tea with strangers](https://cloud.githubusercontent.com/assets/1022843/20679322/46e2a0b2-b54f-11e6-83ff-024a95c735d0.png)
