### PR TITLE
Facelift for Cold Water city pages 

### DIFF
--- a/app/assets/stylesheets/cities/_index.scss
+++ b/app/assets/stylesheets/cities/_index.scss
@@ -36,7 +36,9 @@
 }
 
 .city-cta-header {
-  padding: 3em 0 0.5em;
+  padding: 3em 0 1.5em;
+  border-bottom: 1px $base-border-color solid;
+  margin-bottom: 1.5em;
 
   h1 {
     margin-bottom: $base-font-size/2;
@@ -118,25 +120,27 @@ button.new-city-cta {
   .cities-section {
     margin-bottom: $base-font-size*1.5;
   }
-}
 
-h3.cities-list-header {
-  text-align: center;
-  margin-bottom: $base-font-size*1.5;
+  .cities-list-header {
+    overflow: auto;
+    margin-bottom: 1em;
+    h2 {
+      margin-bottom: 0.5em;
+    }
+  }
 }
 
 .cities-list {
   @include outer-container;
-
+  list-style: none;
+  padding: 0;
+  clear: both; 
+  overflow: auto;
 
   .city {
     position: relative;
     height: 160px;
     margin-bottom: $base-font-size;
-
-    &.no-photo {
-      height: auto;
-    }
 
     @include media($tablet-only) {
 
@@ -189,6 +193,26 @@ h3.cities-list-header {
           text-indent: -9999px;
         }
       }
+    }
+  }
+
+  li.city-no-photo {
+    height: auto;
+    overflow: auto;
+    text-align: center;
+    margin-bottom: $base-font-size;
+    padding: 0 1em; 
+    
+    @include media($tablet-only) {
+
+      @include omega(3n);
+      @include span-columns(4 of 12);
+    }
+
+    @include media($desktop) {
+
+      @include omega(4n);
+      @include span-columns(3 of 12);
     }
   }
 }
@@ -247,7 +271,8 @@ h3.cities-list-header {
 .required-resources,
 .sharing,
 .become-host,
-.host-intro {
+.host-intro,
+.cities-section h3, .cities-section h4 {
 
   @include media($tablet) {
     @include span-columns(10 of 12);

--- a/app/assets/stylesheets/cities/_index.scss
+++ b/app/assets/stylesheets/cities/_index.scss
@@ -1,5 +1,20 @@
 .container.city {
   margin-bottom: $base-font-size*3;
+  &.no-banner {
+    margin-top: $base-font-size*3;
+    .coldwater-letter {
+      background: $tws-white;
+      border: $base-border;
+      padding: 2em 2em;
+      h3 {
+        margin-bottom: 1em;
+        line-height: 1.25em;
+      }
+      p {
+        font-size: 0.9em;
+      }
+    }
+  }
 }
 
 .cities-partial {
@@ -247,17 +262,9 @@ h3.cities-list-header {
 
 input, button {
   &.full-width-button {
-    @include span-columns(12 of 12);
-
-    @include media($tablet) {
-      @include span-columns(10 of 12);
-      @include shift(1);
-    }
-
-    @include media($desktop) {
-      @include span-columns(8 of 12);
-      @include shift(2);
-    }
+    width: auto;
+    max-width: 100%;
+    white-space: normal;
   }
 
   &.text {
@@ -287,10 +294,19 @@ input, button {
   text-align: center;
 
   h3 {
-    margin-bottom: $base-font-size/2;
+    margin-bottom: 1em;
   }
 
-  p, input {
+  button, input {
+    margin-bottom: 1em;
+  }
+
+  h5 {
+    clear: both; 
+    overflow: auto;
+  }
+
+  p {
     margin-bottom: 0;
   }
 }

--- a/app/assets/stylesheets/components/_notifications.scss
+++ b/app/assets/stylesheets/components/_notifications.scss
@@ -18,5 +18,6 @@
 
   &.set-city {
     padding: 1em;
+    margin-bottom: 1em;
   }
 }

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -2,19 +2,23 @@
 <div class='container'>
   <div class="cities-partial">
     <div class="city-cta-header">
-      <h1 class="dark center">Where can we find you?</h1>
-      <p class="header-small">Choose the city you call home to set your home city.</p>
-      <%= link_to suggest_cities_path do %>
-        <button class="button new-city-cta top-button ">Don’t see your city? Add it here!</button>
-      <% end %>
+      <h1 class="dark center">Set your home city</h1>
+      <p class="header-small">Make sure you're the first to hear about Tea With Strangers updates relevant to you!</p>
     </div>
 
     <div class="cities-lists">
       <div class="cities-section">
-        <h3 class='capitalize cities-list-header'>We're in these cities</h3>
+        <div class="cities-list-header"> 
+          <h2 class='center'>
+            We're building our communities here 🏠 
+          </h2>
+          <h4 class="center">
+            You should be able to sign up for a tea time today!
+          </h4>
+        </div>
         <div class="cities-list current-cities-container" data-city-type='active'>
           <% @active_cities.each do |city| %>
-            <div class="city">
+            <div class="city photo">
               <div class="city-image" style="background-image: url('<%= city.header_bg(:small) %>');">
                 <h2 class=" city-name">
                   <%= link_to city.name, city_path(city), class: 'background-filter' %>
@@ -26,24 +30,30 @@
         </div>
       </div>
       <div class="cities-section">
-        <h3 class='capitalize cities-list-header'>We're on our way to these cities</h3>
+        <div class="cities-list-header"> 
+          <h2 class='center'>
+            We'll get here eventually ✈️
+          </h2>
+          <h4>
+            For now, find and set your home city. We'll make sure you know when we Tea With Strangers is coming your way!
+          </h4>
+        </div> 
         <div class="cities-list current-cities-container" data-city-type='active'>
-          <% @upcoming_cities.each do |city| %>
-            <div class="city">
-              <div class="city-image" style="background-image: url('<%= city.header_bg(:small) %>');">
-                <h2 class=" city-name">
-                  <%= link_to city.name, city_path(city), class: 'background-filter' %>
-                  <%= link_to city.name, city_path(city), class: 'city-name' %>
-                </h2>
-              </div>
-            </div>
-          <% end %>
+          <div class="suggest">
+            <%= link_to suggest_cities_path do %>
+              <button class="button new-city-cta top-button ">Don’t see your city? Add it here!</button>
+            <% end %>
+          </div>
+          <ul class="cities-list">
+            <% @upcoming_cities.each do |city| %>
+              <li class="city-no-photo">
+                <%= link_to city.name, city_path(city) %>
+              </li>
+            <% end %>
+          </ul>
         </div>
       </div>
     </div>
-    <%= link_to suggest_cities_path do %>
-      <button class="btn new-city-cta">Don't see your city? Add it here!</button>
-    <% end %>
   </div>
 </div>
 <%= render partial: 'shared/new_footer' %>

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -3,7 +3,7 @@
   <div class="cities-partial">
     <div class="city-cta-header">
       <h1 class="dark center">Where can we find you?</h1>
-      <p class="header-small">Choose the city where you'd like to join for tea time</p>
+      <p class="header-small">Choose the city you call home to set your home city.</p>
       <%= link_to suggest_cities_path do %>
         <button class="button new-city-cta top-button ">Don’t see your city? Add it here!</button>
       <% end %>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -14,17 +14,27 @@
 <% end %>
 
 <div class="light-background">
-<%= render partial: 'cities/show/city_banner' %>
-
-<div class="container city">
-  <div class="city-info">
-  	<% if @city.unapproved? %>
-  	  <%= render partial: 'cities/show/unconfirmed' %>
-  	<% elsif @city.cold_water? %>
-  	  <%= render partial: 'cities/show/cold_water' %>
-  	<% else %>
-      <%= render partial: 'cities/show/active' %>
-  	<% end %>
-  </div>
+  <% if @city.unapproved? %>
+    <%= render partial: 'shared/header' %>
+    <div class="container city no-banner">
+      <div class="city-info">
+        <%= render partial: 'cities/show/unconfirmed' %>
+      </div>
+    </div>
+  <% elsif @city.cold_water? %>
+    <%= render partial: 'shared/header' %>
+    <div class="container city no-banner">
+      <div class="city-info">
+        <%= render partial: 'cities/show/cold_water' %>
+      </div>
+    </div>
+  <% else %>
+    <%= render partial: 'cities/show/city_banner' %>
+    <div class="container city">
+      <div class="city-info">
+        <%= render partial: 'cities/show/active' %>
+      </div>
+    </div>
+  <% end %>
 </div>
 <%= render partial: 'shared/new_footer' %>

--- a/app/views/cities/show/_city_banner.html.erb
+++ b/app/views/cities/show/_city_banner.html.erb
@@ -5,7 +5,7 @@
       <h1 class="cover-photo-lede city-title"><%= @city.name %></h1>
       <% if @city.pending? %>
         <span class='cover-photo-subtext city-subtext'>
-          Coming Soon
+          We'll get there eventually!
         </span>
       <% elsif @city.pending_approval? %>
         <span class='cover-photo-subtext city-subtext'>

--- a/app/views/cities/show/_cold_water.html.erb
+++ b/app/views/cities/show/_cold_water.html.erb
@@ -1,25 +1,57 @@
-<div class="section city-intro">
-	<h2 class="section-header">Bring Tea With Strangers to <%= @city.name %></h2>
-	<p class="last">
-		Tea With Strangers is all about getting rid of strangers and making our cities feel like neighborhoods. This dreamland doesn’t become real with a website, facebook status, or an #instacommunity hashtag. We need people to start making tea time happen!
-	</p>
-	<% if !user_signed_in? %>
-		<%= link_to sign_up_path do %>
-			<button class='orange full-width-button'>
-				Let's Get Tea
-			</button>
-		<% end %>
-	<% else %>
-		<%= render partial: 'cities/show/set_city' %>
-	<% end %>
+<div class="section city-intro coldwater-letter">
+	<h2 class="section-header">
+    Dear <%= @city.name %>,
+  </h2>
+  <h3>
+    We don't have an ETA for when we'll get to you yet. The moment we do, <%= @city.users.count %> of you will be emailed about it.
+  </h3>
+  <p>
+    Right now, we're focusing on doing the best job we can in 
+      <a href="http://www.teawithstrangers.com/NYC" target="_blank">New York</a>, 
+      <a href="http://www.teawithstrangers.com/SF" target="_blank">San Francisco and the Bay Area</a>, 
+      <a href="http://www.teawithstrangers.com/LONDON" target="_blank">London</a>, 
+      <a href="http://www.teawithstrangers.com/BOS" target="_blank">Boston</a>, 
+      <a href="http://www.teawithstrangers.com/CHI" target="_blank">Chicago</a>, and
+      <a href="http://www.teawithstrangers.com/DC" target="_blank">DC</a>.
+  </p>
+  <p>
+    That means finding amazing hosts, fostering a strong community amongst them, ensuring that tea times are happening regularly, and that every conversation inspires questions, new perspectives, and the reminder that we're far more the same than we are different.
+  </p>
+  <p>
+    We're still trying to nail the formula to do this well, and when we have more of the puzzle made out, we'll bring Tea With Strangers to more cities.
+  </p>
+  <h3>
+    For now, set your home city so you'll get that email too.
+  </h3>
+  <%= render partial: 'cities/show/set_city' %>
+  <h3>
+    If you're bummed about having to wait...
+  </h3> 
+  <p>
+    Go to your local park, library, cafe, or any other community center and ask someone how they're doing. 
+  </p>
+  <p>
+    Tea With Strangers is a slightly less fear-inducing way of doing pretty much that, but you have all the courage you need to make this happen yourself. Really.
+  </p>
+  <h3>
+    If you are ever in 
+      <a href="http://www.teawithstrangers.com/NYC" target="_blank">NYC</a>, 
+      <a href="http://www.teawithstrangers.com/SF" target="_blank">SF</a>, 
+      <a href="http://www.teawithstrangers.com/LONDON" target="_blank">London</a>, 
+      <a href="http://www.teawithstrangers.com/BOS" target="_blank">Boston</a>, 
+      <a href="http://www.teawithstrangers.com/CHI" target="_blank">Chicago</a>, or
+      <a href="http://www.teawithstrangers.com/DC" target="_blank">DC</a>...
+  </h3>
+  <p>
+    Go to the appropriate city page and go to a tea time there! And tell your friends in those cities to go to tea times and live vicariously through them!
+  </p>
+  <h3>
+    If you want to become a host when we're ready to go in <%= @city.name %>...
+  </h3>
+  <p>
+    Let us know that you want to become a host by going here: <%= link_to "Hosting With Tea With Strangers", hosting_path %>.
+  </p>
 </div>
-<div class="section required-resources line-divide">
-	<%= render partial: 'cities/show/required_resources' %>
-</div>
-<div class="section sharing line-divide">
-	<%= render partial: 'shared/sharing_widget', locals: { full: true } %>
-</div>
-
 <div class="section learn-more">
 	<%= render partial: 'shared/learn_more' %>
 </div>

--- a/app/views/cities/show/_set_city.html.erb
+++ b/app/views/cities/show/_set_city.html.erb
@@ -1,21 +1,40 @@
 <div class="notification alert set-city">
   <div class="set-city">
-    <% if current_user && current_user.home_city.nil? %>
-      <h3 class="center">You have no home city yet!</h3>
-      <%= form_for(@city, url: set_city_path(@city), method: :put) do |f|%>
-        <%= f.submit "This is my home city", class: 'full-width-button' %>
+    <% if !user_signed_in? %>
+      <h3 class="center">
+        You can set your city once you've signed up!
+      </h3>
+      <%= link_to sign_up_path do %>
+        <button class='orange full-width-button'>
+          Sign Up
+        </button>
       <% end %>
-    <% elsif current_user && current_user.home_city != @city%>
-      <p>
+      <%= link_to new_user_session_path do %>
+        <h5> 
+          Log in if you've signed up before
+        </h5>
+      <% end %>
+    <% else %>
+      <% if current_user && current_user.home_city.nil? %>
+        <h3 class="center">You have no home city yet!</h3>
         <%= form_for(@city, url: set_city_path(@city), method: :put) do |f|%>
-          <h3 class="center">
-            <%= current_user.home_city.name %> is your home city.
-          </h3>
-          <%= f.submit "Click here to change your city to #{@city.name}.", class: 'text' %>
+          <%= f.submit "Set #{@city.name} as my home city", class: 'full-width-button' %>
         <% end %>
-      </p>
-    <% elsif current_user && current_user.home_city == @city%>
-      <p><strong>This is your home city!</strong> If that's wrong, <%= link_to 'go here to change it.', cities_path %></p>
+      <% elsif current_user && current_user.home_city != @city%>
+        <p>
+          <%= form_for(@city, url: set_city_path(@city), method: :put) do |f|%>
+            <h3 class="center">
+              Do you live in <%= "#{@city.name}" %> now?
+            </h3>
+            <%= f.submit "Yes. #{@city.name} should be my home city", class: 'full-width-button' %>
+            <h5>
+              <%= link_to current_user.home_city.name, city_path(current_user.home_city) %> is your home city right now. The big button will change that!
+            </h5>
+          <% end %>
+        </p>
+      <% elsif current_user && current_user.home_city == @city%>
+        <p><strong>This is your home city!</strong> If you've moved, <%= link_to 'change your home city here', cities_path %>.</p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/cities/show/_set_city.html.erb
+++ b/app/views/cities/show/_set_city.html.erb
@@ -26,7 +26,7 @@
             <h3 class="center">
               Do you live in <%= "#{@city.name}" %> now?
             </h3>
-            <%= f.submit "Yes. #{@city.name} should be my home city", class: 'full-width-button' %>
+            <%= f.submit "Yes, #{@city.name} should be my home city", class: 'full-width-button' %>
             <h5>
               <%= link_to current_user.home_city.name, city_path(current_user.home_city) %> is your home city right now. The big button will change that!
             </h5>

--- a/app/views/city_suggestions/new.html.erb
+++ b/app/views/city_suggestions/new.html.erb
@@ -33,14 +33,14 @@
         <% end %>
       </div>
       <div class="active-city-list">
-        <h3 class="capitalize center current-cities-header">Or click your city below if we're already there</h3>
-        <div class="cities-list">
+        <h3 class="capitalize center current-cities-header">Or click your city below if we already have it covered</h3>
+        <ul class="cities-list">
           <% City.visible.each do |c| %>
-            <div class="city no-photo">
+            <li class="city-no-photo">
               <%= link_to c.name, city_path(c) %>
-            </div>
+            </li>
           <% end %>
-        </div>
+        </ul>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This adjusts the view of cold water cities on `/cities` and completely changes the way cold water city pages look to better reflect our intentions.

* Eliminates progress bars
* Directs CTA to 'set home city'
* Adjusted views and copy for /cities page to better direct users

This is what /cities looks like:

![2016-11-28 at 9 38 am](https://cloud.githubusercontent.com/assets/1022843/20679135/81905a5c-b54e-11e6-87cd-e35cf28d5695.png)

This is what a 'upcoming city' page will look like. The first line updates with the number of users who have that city set as their home city

![2016-11-28 at 9 40 am](https://cloud.githubusercontent.com/assets/1022843/20679172/a6b1f4a8-b54e-11e6-9509-92f617556dab.png)

If the user has a different home city, this is what the upcoming city page looks like:

![2016-11-28 at 9 41 am](https://cloud.githubusercontent.com/assets/1022843/20679211/cded1a2a-b54e-11e6-958e-b0f76b9fcbbd.png)
