### PR TITLE
add cities link to nav bar for users with home city

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -22,6 +22,9 @@
           <li class="nav-link-item">
             <%= link_to current_user.home_city.name, city_path(current_user.home_city) %>
           </li>
+          <li class="nav-link-item">
+            <%= link_to "Cities", cities_path %>
+          </li>
         <% end %>
 
         <% if !current_user || (current_user && !current_user.host?) %>


### PR DESCRIPTION
/cities was hard to find for a user who already had home city set
now it's not

if a user doesn't have a home city...
![2016-11-28 at 9 11 am](https://cloud.githubusercontent.com/assets/1022843/20678195/ad0149b6-b54a-11e6-9158-17cab3f9f753.png)

if a user has a home city
![2016-11-28 at 9 11 am](https://cloud.githubusercontent.com/assets/1022843/20678223/c3361144-b54a-11e6-8749-3f667c10c3ce.png)

if a user is a host and has a home city

![2016-11-28 at 9 12 am](https://cloud.githubusercontent.com/assets/1022843/20678241/d41cc5fc-b54a-11e6-81e8-7c629ed22102.png)
