### PR TITLE
pin create tt button to navbar for hosts

### DIFF
--- a/app/views/profiles/_navbar.html.erb
+++ b/app/views/profiles/_navbar.html.erb
@@ -1,13 +1,5 @@
 <div class="dash-menu-container">
   <div class="dash-menu">
-    <% if current_user.host? || current_user.admin? %>
-      <ul class="dash-menu-list standout">
-        <li class="nav-link-item new-tea">
-          <%= link_to "Create New Tea Time!", new_tea_time_path %>
-        </li>
-      </ul>
-    <% end %>
-
     <ul id="profile-nav" class="dash-menu-list">
       <li class="nav-link-item">
         <%= link_to "Quick Look", profile_path %>
@@ -24,6 +16,9 @@
           <%= link_to "Edit Profile", host_profile_path %>
         </li>
       <% end %>
+      <li class="nav-link-item">
+        <%= link_to "Account Details", edit_user_registration_path %>
+      </li>
     </ul>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,6 +5,9 @@
     <nav class='nav-list'>
       <ul class='nav-links'>
         <% if current_user && current_user.host? %>
+          <li class="nav-link-item new-tea">
+            <%= link_to "Post Tea Time", new_tea_time_path, class: 'nav-emphasis' %>
+          </li>
           <li class="nav-link-item">
             <%= link_to current_user.nickname, host_city_path(current_user.home_city, current_user) %>
           </li>
@@ -43,9 +46,6 @@
         <% else %>
           <li class="nav-link-item">
             <%= link_to 'Dashboard', profile_path %>
-          </li>
-          <li class="nav-link-item">
-            <%= link_to "Account", edit_user_registration_path %>
           </li>
           <li class='nav-link-item'>
             <%= link_to('Sign out', destroy_user_session_path, method: :delete) %>


### PR DESCRIPTION
![2016-11-28 at 9 08 am](https://cloud.githubusercontent.com/assets/1022843/20678079/4a8e191c-b54a-11e6-8064-e27d22c07c3c.png)

this might increase host login > tt creation conversion
probably a negligible diff but the button should've been here the whole time anyway

![2016-11-28 at 9 09 am](https://cloud.githubusercontent.com/assets/1022843/20678094/58bc9ab8-b54a-11e6-8758-67cc6f1c1e3a.png)

also moved the 'account details' link to the dashboard navbar instead of the main one, as it frees up space on the nav bar and makes the navigation experience a bit tighter