### PR TITLE
add a `commitment` field for how often a host plans to host

### DIFF
--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -51,7 +51,7 @@ class City < ActiveRecord::Base
   def hosts
     User.hosts.where(home_city: [self] + proxy_cities)
   end
-  
+
   def hosts_by_status
     users = User.hosts.where(home_city: self.id).includes(:host_detail).group_by {|h| h.host_detail.activity_status }
     # Return empty array if there are no users in that group

--- a/db/migrate/20170203195548_add_commitment_to_host_details.rb
+++ b/db/migrate/20170203195548_add_commitment_to_host_details.rb
@@ -1,0 +1,9 @@
+class AddCommitmentToHostDetails < ActiveRecord::Migration
+  def up
+    add_column :host_details, :commitment, :integer
+  end
+
+  def down
+    remove_column :host_details, :commitment, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001202222) do
+ActiveRecord::Schema.define(version: 20170203195548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20161001202222) do
     t.integer  "activity_status", default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "commitment"
   end
 
   create_table "proxy_cities", force: true do |t|


### PR DESCRIPTION
Add a field to keep track of host-entered commitment, as described in this spec:

https://docs.google.com/document/d/1x-FGvNez_v0zrKgtD3dOQo1JTB742ZVY3LOqIPPvWyo/edit#heading=h.l3domrrdcq5q

@nickbarnwell (cc @ankitshah811 )