### PR TITLE
add form for hosts to input commitment

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,38 @@
+var bindCommitmentForm = function() {
+  var form = $('#commitment-form');
+  var input = $('#commitment-regular');
+  updateCommitmentForm();
+  form.on('change', updateCommitmentForm);
+  updateCustomField()
+  form.on('change', updateCustomField)
+}
+
+updateCommitmentForm = function() {
+  var buttons = $('#nested-radio-buttons');
+  var inputs = buttons.find('input');
+  if($('#commitment-regular').is(':checked')) {
+    buttons.removeClass('faded');
+    inputs.each(function(i, input) {
+      input.disabled = false;
+    })
+  } else {
+    buttons.addClass('faded');
+    inputs.each(function(i, input) {
+      input.disabled = true;
+      input.checked = false;
+    });
+  }
+}
+
+updateCustomField = function() {
+  var input = $('#custom-commitment');
+  if($('#user_commitment_detail_custom').is(':checked')) {
+    input.prop('disabled', false);
+  } else {
+    input.prop('disabled', true);
+    $("#custom-commitment").val("");
+  }
+}
+
+$(document).ready(bindCommitmentForm);
+$(document).on('page:load', bindCommitmentForm);

--- a/app/assets/stylesheets/components/_dashboard-forms.scss
+++ b/app/assets/stylesheets/components/_dashboard-forms.scss
@@ -129,6 +129,77 @@ These are styles related to forms within the user or host dashboards
   }
 }
 
+.radio-buttons {
+  label {
+    width: 100%;
+    display: inline-block;
+    input {
+      width: 25px;
+      display: inline-block;
+    }
+  }
+  #nested-radio-buttons {
+    padding-left: 5%;
+    label {
+      display: inline-block;
+      padding-right: 1.5%;
+      font-size: 14px;
+      margin-bottom: 0;
+      width: auto;
+    }
+    input {
+      margin-bottom: 0;
+      width: 25px;
+      display: inline-block;
+    }
+    [type="text"] {
+      border-top: none;
+      border-right: none;
+      border-left: none;
+      border-radius: 0;
+      padding: 0.3em;
+      text-align: center;
+      margin-bottom: 0;
+    }
+  }
+}
+
+.edit-host-commitment {
+  .title {
+    width: 80%;
+    border: solid $tws-orange 1px;
+    border-radius: 2px;
+    background-color: white;
+    margin: 0 auto;
+    margin-bottom: -1em;
+    font-size: 0.8em;
+    font-weight: bold;
+    padding: .2em 0;
+    text-align: center;
+    position: relative;
+  }
+
+  .orange {
+    color: $tws-orange;
+  }
+
+  .details {
+    border: solid $tws-orange 1px;
+    border-radius: 2px;
+    padding: 1em;
+    padding-top: 1.5em;
+    font-size: 0.8em;
+    .button {
+      margin-top: 10px;
+      font-size: 1em !important;
+    }
+  }
+}
+
+.faded {
+  opacity: 0.4;
+}
+
 .cancel-account {
 	input.cancel-account {
 		@include inverted-button($tws-orange, $tws-orange);
@@ -193,7 +264,7 @@ These are styles related to forms within the user or host dashboards
   }
 }
 .form.email-reminder, .form.create-tea, .form.edit-tea {
-  
+
   .form-checkbox input[type="checkbox"] {
     display: inline-block;
     width: auto;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,8 +58,8 @@ class ApplicationController < ActionController::Base
       permitted = [:nickname, :family_name, :given_name, :email, :password,
                    :password_confirmation, :avatar, :current_password,
                    :tagline, :summary, :topics, :story, :home_city_id,
-                   :facebook, :twitter, :phone_number]
-
+                   :facebook, :twitter, :phone_number, :commitment_overview,
+                   :commitment_detail]
       [:sign_up, :account_update].each do |s|
         devise_parameter_sanitizer.for(s) do |u|
           u.permit(*permitted)

--- a/app/mailers/attendance_mailer.rb
+++ b/app/mailers/attendance_mailer.rb
@@ -130,7 +130,7 @@ class AttendanceMailer < ActionMailer::Base
 
     @host = @tea_time.host
     mail(to: @host.friendly_email,
-         subject: "Mark attendance for your tea time!") do |format|
+         subject: "Mark attendance for your tea time (and other housekeeping)") do |format|
       format.text
       format.html
     end

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -15,4 +15,120 @@ class HostMailer < ActionMailer::Base
       format.html
     end
   end
+
+  def host_drip(latest_tea_time_id, drip_index = nil)
+    @tt = TeaTime.find_by_id(latest_tea_time_id)
+    cancel_delivery unless @tt
+    @host = @tt.host
+    @drip_index = drip_index
+    cancel_delivery unless @host.commitment_overview == HostDetail::REGULAR_COMMITMENT
+
+    subject = case drip_index
+    when 0
+      "Your next tea time"
+    when 1
+      "Hi there"
+    when 2
+      "Moving oolong 🍵"
+    else
+      "🤗: Knock knock! 🤔: Who’s there?"
+    end
+
+    mail(to: @host.email,
+         subject: subject) do |format|
+      format.text
+      format.html
+    end
+  end
+
+  def host_drip_reminder(latest_tea_time_id, drip_index)
+    @tt = TeaTime.find_by_id(latest_tea_time_id)
+    cancel_delivery unless @tt
+    @host = @tt.host
+    @drip_index = drip_index
+    cancel_delivery unless @host.commitment_overview == HostDetail::REGULAR_COMMITMENT
+
+    subject = case drip_index
+    when 0
+      "Your next tea time"
+    when 2
+      "Moving oolong 🍵"
+    end
+
+    mail(to: @host.email,
+         subject: subject) do |format|
+      format.text
+      format.html
+    end
+  end
+
+  def no_commitment_drip(latest_tea_time_id, drip_index = nil)
+    @tt = TeaTime.find_by_id(latest_tea_time_id)
+    cancel_delivery unless @tt
+    @host = @tt.host
+    cancel_delivery unless @host.commitment_overview == HostDetail::NO_COMMITMENT
+    @drip_index = drip_index
+
+    subject = case drip_index
+    when 0
+      "Thinking about ya"
+    else
+      "It’s been a while!"
+    end
+
+    mail(to: @host.email,
+         subject: subject) do |format|
+      format.text
+      format.html
+    end
+  end
+
+  def no_commitment_drip_reminder(host_id)
+    @host = User.find_by_id(host_id)
+    cancel_delivery unless @host
+    cancel_delivery unless @host.commitment_overview == HostDetail::NO_COMMITMENT
+
+    mail(to: @host.email,
+         subject: "Thinking about ya") do |format|
+      format.text
+      format.html
+    end
+  end
+
+  def pause(host_id)
+    @host = User.find_by_id(host_id)
+    cancel_delivery unless @host
+    cancel_delivery unless @host.commitment_overview == HostDetail::INACTIVE_COMMITMENT
+
+    mail(to: @host.email,
+         subject: "We just heard the news…") do |format|
+      format.text
+      format.html
+    end
+  end
+
+  def inactive_host_posted(host_id)
+    @host = User.find_by_id(host_id)
+    cancel_delivery unless @host
+    cancel_delivery unless @host.commitment_overview == HostDetail::INACTIVE_COMMITMENT
+    cancel_delivery unless @host.tea_times.future.pending.any?
+
+    mail(to: @host.email,
+         subject: "Hello again!") do |format|
+      format.text
+      format.html
+    end
+  end
+
+  def commitment_intro(host_id)
+    @host = User.find_by_id(host_id)
+    cancel_delivery unless @host
+    cancel_delivery if @host.commitment_overview == HostDetail::INACTIVE_COMMITMENT
+     
+    mail(to: @host.email,
+         subject: "Sweet! Here’s how this works") do |format|
+      format.text
+      format.html
+    end
+  end
 end

--- a/app/models/host_detail.rb
+++ b/app/models/host_detail.rb
@@ -26,11 +26,11 @@ class HostDetail < ActiveRecord::Base
     2 => 'Two times a month',
     4 => 'Once a month',
     8 => 'Once every two months',
-    'custom' => 'Every __ weeks',
   }
 
   REGULAR_COMMITMENT = 'regular'
   CUSTOM_COMMITMENT = 'custom'
   IRREGULAR_COMMITMENTS = COMMITMENT_OVERVIEW - [REGULAR_COMMITMENT]
+  NO_COMMITMENT = 0
   INACTIVE_COMMITMENT = -1
 end

--- a/app/models/host_detail.rb
+++ b/app/models/host_detail.rb
@@ -1,4 +1,36 @@
 class HostDetail < ActiveRecord::Base
   belongs_to :user
   enum activity_status: { inactive: 0, active: 1, legacy: 2 }
+  validates :commitment, numericality: { only_integer: true }
+
+  COMMITMENT_OVERVIEW = [
+    'regular',
+    0,
+    -1,
+  ]
+
+  COMMITMENT_OVERVIEW_TEXT = {
+    'regular' => 'I will commit to hosting regularly.',
+    0 => 'I\'ll host when I want.',
+    -1 => 'I don\'t plan to host tea times anymore.',
+  }
+
+  COMMITMENT_DETAILS = [
+    2,
+    4,
+    8,
+    'custom',
+  ]
+
+  COMMITMENT_DETAILS_TEXT = {
+    2 => 'Two times a month',
+    4 => 'Once a month',
+    8 => 'Once every two months',
+    'custom' => 'Every __ weeks',
+  }
+
+  REGULAR_COMMITMENT = 'regular'
+  CUSTOM_COMMITMENT = 'custom'
+  IRREGULAR_COMMITMENTS = COMMITMENT_OVERVIEW - [REGULAR_COMMITMENT]
+  INACTIVE_COMMITMENT = -1
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,12 +60,22 @@ class User < ActiveRecord::Base
 
   def commitment_overview=(overview)
     if overview.to_s != HostDetail::REGULAR_COMMITMENT.to_s
+      if commitment.nil?
+        if overview.to_s == HostDetail::NO_COMMITMENT.to_s
+          HostMailer.commitment_intro(id).deliver
+        elsif overview.to_s == HostDetail::INACTIVE_COMMITMENT.to_s
+          HostMailer.pause(id).deliver
+        end
+      end
       host_detail.commitment = overview
       host_detail.save!
     end
   end
 
   def commitment_detail=(detail)
+    if commitment.nil? && detail
+      HostMailer.commitment_intro(id).deliver
+    end
     if detail.to_i > 0
       host_detail.commitment = detail
       host_detail.save!
@@ -144,6 +154,45 @@ class User < ActiveRecord::Base
 
   def tws_interests
     super || {'hosting' => false, 'leading' => false }
+  end
+
+  def send_drip_email(tea_time)
+    return unless commitment
+    return if commitment == HostDetail::INACTIVE_COMMITMENT
+    return unless tea_time
+    tt_time = tea_time.start_time
+    tt_date = tt_time.to_date
+    return if tt_date > Date.today
+    if commitment == HostDetail::NO_COMMITMENT
+      drip_delay = 3.weeks
+      reminder_delay = 2.days
+      recurring_reminder_delay_months = 3
+      if tt_date + drip_delay == Date.today
+        HostMailer.no_commitment_drip(tea_time.id, 0).deliver
+      elsif tt_date + drip_delay + reminder_delay == Date.today
+        HostMailer.no_commitment_drip_reminder(id).deliver
+      else # Every 3 months
+        month_difference = (Date.today.year * 12 + Date.today.month) - (tt_date.year * 12 + tt_date.month)
+        cycles_mod = month_difference % recurring_reminder_delay_months
+        if tt_date.day == Date.today.day && (cycles_mod == 0)
+          HostMailer.no_commitment_drip(tea_time.id, month_difference / recurring_reminder_delay_months).deliver
+        end
+      end
+    else
+      drip_delays = [0.5, 1, 1.5].map{ |n| n * commitment.weeks }
+      reminder_delays = [2.days, nil, 2.days]
+      drip_delays.each_with_index do |delay, i|
+        if (tt_time + delay).to_date == Date.today
+          return HostMailer.host_drip(tea_time.id, i).deliver
+        elsif reminder_delays[i] && (tt_time + delay + reminder_delays[i]).to_date == Date.today
+          return HostMailer.host_drip_reminder(tea_time.id, i).deliver
+        end
+      end
+      cycles_passed = (Date.today - tt_date).to_f / (commitment * 7) + 1
+      if cycles_passed % 1 == 0
+        HostMailer.host_drip(tea_time.id, cycles_passed).deliver
+      end
+    end
   end
 
   class << self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ActiveRecord::Base
   validates_with Validators::FacebookUrlValidator
   validates_with Validators::TwitterHandleValidator
 
+  delegate :commitment, to: :host_detail
+
   before_destroy :flake_future
   after_create :generate_host_detail
 
@@ -42,6 +44,43 @@ class User < ActiveRecord::Base
 
   def name=(name)
     nickname = name
+  end
+
+  def commitment_overview
+    if commitment.nil? || HostDetail::IRREGULAR_COMMITMENTS.include?(commitment)
+      commitment
+    else
+      HostDetail::REGULAR_COMMITMENT
+    end
+  end
+
+  def commitment_detail
+    commitment
+  end
+
+  def commitment_overview=(overview)
+    if overview.to_s != HostDetail::REGULAR_COMMITMENT.to_s
+      host_detail.commitment = overview
+      host_detail.save!
+    end
+  end
+
+  def commitment_detail=(detail)
+    if detail.to_i > 0
+      host_detail.commitment = detail
+      host_detail.save!
+    end
+  end
+
+  def commitment_text
+    HostDetail::COMMITMENT_OVERVIEW_TEXT[commitment] ||
+        HostDetail::COMMITMENT_OVERVIEW_TEXT[HostDetail::REGULAR_COMMITMENT]
+  end
+
+  def custom_commitment
+    if commitment_overview == HostDetail::REGULAR_COMMITMENT && !HostDetail::COMMITMENT_DETAILS.include?(commitment)
+      commitment
+    end
   end
 
   def twitter_url

--- a/app/views/attendance_mailer/mark_attendance_reminder.markerb
+++ b/app/views/attendance_mailer/mark_attendance_reminder.markerb
@@ -1,12 +1,17 @@
-<%= @tea_time.host.name %>! Hope you had an awesome tea time. Quickly, before you get to the rest of your life...
+<%= @host.nickname %>! Hope you had an awesome tea time. Quick housekeeping (before you get to the rest of your life):
 
-**[Mark attendance from your tea time](<%= url_for(controller: :profiles, action: :host_tasks, only_path: false) %>)**. Be sure to check off anyone you'd invite to make a great host!
+[Mark attendance from your tea time](<%= url_for(controller: :profiles, action: :host_tasks, only_path: false) %>). Be sure to check off anyone you'd invite to make a great host!
 
 Afterwards, send the attendees a little thank you note with all sorts of good vibes.
 
-[All of it takes seconds](<%= url_for(controller: :profiles, action: :host_tasks, only_path: false) %>).
+[All of it takes seconds](<%= url_for(controller: :profiles, action: :host_tasks, only_path: false) %>), and it helps us keep track of things hugely.
 
-You the best!
+<% if @host.commitment_overview == HostDetail::REGULAR_COMMITMENT %>
+  <% commitment = @host.commitment_detail %>
+  [Oh, and get your next tea time up](<%= url_for(controller: :tea_times, action: :new, only_path: false) %>)! You’ve committed to hosting every <%= commitment %> weeks, so your next tea time should be sometime between now and <%= (Date.today + commitment.weeks).strftime("%B %e, %Y") %>. They’re more likely to fill up the more ahead of time you post 🤓
+<% else %>
+  If you’re feeling inspired, [schedule your next tea time](<%= url_for(controller: :tea_times, action: :new, only_path: false) %>)!
+<% end %>
 
-Bleep bleep bloop,  
-The Robots at Tea With Strangers
+Bip bop zip,  
+TWS Robots

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -136,11 +136,54 @@
           </div>
         </div>
 
-
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
           <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
         <% end %>
 
+        <% if resource.host? %>
+          <h3 class="form-subheader">
+            How often do you want to host tea time?
+          </h3>
+
+          <div class="field">
+            <div class="form-label">
+              <%= f.label :commitment, 'Committing makes TWS better.', class: 'capitalize boldweight' %>
+              <span class="sub-label light">
+                By telling us how regularly you want to host, we'll be better positioned to support your hosting goals by driving strangers to your tea times and sending you reminders to post a tea time when you need them.
+              </span>
+            </div>
+            <div id='commitment-form' class='radio-buttons'>
+              <% HostDetail::COMMITMENT_OVERVIEW.each do |overview| %>
+                <div>
+                  <label>
+                    <% params = {} %>
+                    <% params.merge!({ id: 'commitment-regular'}) if overview == HostDetail::REGULAR_COMMITMENT %>
+                    <%= f.radio_button :commitment_overview, overview, params %>
+                    <span><%= HostDetail::COMMITMENT_OVERVIEW_TEXT[overview] %></span>
+                    <% if overview == HostDetail::REGULAR_COMMITMENT %>
+                      <div id='nested-radio-buttons'>
+                        <% HostDetail::COMMITMENT_DETAILS.each do |detail| %>
+                          <label>
+                            <% if detail == HostDetail::CUSTOM_COMMITMENT %>
+                              <%= f.radio_button :commitment_detail, detail, { checked: !!resource.custom_commitment } %>
+                              <span>Every</span>
+                                <% params = { id: 'custom-commitment', value: resource.custom_commitment} %>
+                                <%= f.text_field :commitment_detail, params %>
+                              <span>weeks.</span>
+                            <% else %>
+                              <%= f.radio_button :commitment_detail, detail %>
+                              <span> <%= HostDetail::COMMITMENT_DETAILS_TEXT[detail] %> </span>
+                            <% end %>
+                          </label>
+                        <% end %>
+                      </div>
+                    <% end %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
 
         <h3 class="form-subheader">
           Change Your Password
@@ -179,6 +222,7 @@
         </div>
       <% end %>
     </div>
+    <br>
     <div class="cancel-account">
       <h2>
         Cancel my account

--- a/app/views/host_mailer/commitment_intro.markerb
+++ b/app/views/host_mailer/commitment_intro.markerb
@@ -1,0 +1,26 @@
+<% settings_url = url_for(controller: :registrations, action: :edit, only_path: false) %>
+<% if @host.commitment == HostDetail::NO_COMMITMENT %>
+  Hey! Just confirming that you just set your Host Commitment to “I’ll host when I want.” 
+
+  So you know — setting Host Commitment on the website makes it easier for us to help you host as often as you’d like. Since you haven’t set a specific frequency for your commitment, you can expect to get a reminder to host tea time once in a while. 
+
+  They won’t be too frequent, as they’re just meant to let you know that hosting tea time is always something you can do whenever the inspiration strikes. 
+
+  You can always adjust your commitment by going to [your Account Settings](<%= settings_url %>).
+
+  That’s all! We should be getting oolong now. Happy tea times!  
+  TWS Robots
+<% elsif @host.commitment != HostDetail::INACTIVE_COMMITMENT %>
+  Hey, just heard that you’re planning to host every <%= @host.commitment %> weeks! That’s awesome.  
+
+  So you know — this is just meant to help you host as often as you’d like. 
+
+  For us behind the scenes at TWS, it helps us make sure we’re getting enough people to the website to keep your tea times well-stocked with strangers :)
+
+  It’s not binding, and nothing happens to you if you don’t uphold the commitment, but you’ll get emails every so often to nudge ya to post tea times as often as you said you’d like to. 
+
+  You can always adjust your commitment by going to [Account Settings](<%= settings_url %>).
+
+  That’s all! We should be getting oolong now. Happy tea times!  
+  TWS Robots
+<% end %>

--- a/app/views/host_mailer/host_drip.markerb
+++ b/app/views/host_mailer/host_drip.markerb
@@ -1,0 +1,56 @@
+<% commitment = @host.commitment_detail %>
+<% half_commitment = commitment % 2 == 0 ? commitment / 2 : commitment.to_f / 2 %>
+<% new_tt_url = url_for(controller: :tea_times, action: :new, only_path: false) %>
+<% commitment_url = url_for(controller: :registrations, action: :edit, only_path: false) %>
+<% case @drip_index %>
+<% when 0 %>
+  Hey there, quick nudge. You mentioned you’d want to host every <%= commitment %> weeks, and it’s been <%= half_commitment %> weeks since your last tea (on <%= @tt.start_time.strftime("%B %e") %>). 
+
+  📅 Try to [schedule your next tea time](<%= new_tt_url %>) sometime between now and <%= (@tt.start_time + commitment.weeks).strftime("%B %e") %>. 
+
+  Fascinating conversations, childlike curiosity, and strangers await!
+
+  Bleep bloop,  
+  TWS Robots
+
+  PS If you need to adjust your commitment frequency, [you can do that here](<%= commitment_url %>).
+<% when 1 %>
+  Just thinking about ya. Your last tea time was <%= commitment %> weeks ago.* 
+
+  Life gets busy sometimes, but that’s usually a good sign to slow down with a warm drink and good company. [Tea time is a great time to do that](<%= new_tt_url %>).
+
+  Until the next automatic email,  
+  TWS Robots
+
+  *You mentioned wanting to host every <%= commitment %> weeks on the website, so now’s a good time to uphold that commitment. If you want to change it, [feel free to do so here](<%= commitment_url %>). 
+<% when 2 %>
+  We spent a good five minutes thinking of puns for this last subject line. If you took the same amount of time, you could...
+
+  - Think back to what a great tea time feels like
+  - Reflect on friendships you’ve made through Tea With Strangers
+  - Meditate on a good question you’d want to ask someone
+  - [Schedule your next tea time](<%= new_tt_url %>)
+  - Tell your friends to tell their friends that you haven’t met yet about said tea time
+  - Have a great conversation to look forward to
+
+  We conveniently linked the one that our website can help with 🤓
+
+  Your last tea time was on <%= @tt.start_time.strftime("%B %e") %>, <%= half_commitment * 3 %> weeks ago. If you still want to host every <%= commitment %> weeks, now’s a great time to [put a tea time up](<%= new_tt_url %>). If not, feel free to adjust your hosting commitment [here](<%= commitment_url %>).
+
+  Missing you the way only an automated email could,  
+  TWS Robots
+<% else %>
+  A generic reminder email!
+
+  You’re signed up to host tea times every <%= commitment %> weeks, but your last one was <%= (Date.today - @tt.start_time.to_date).to_i / 7 %> weeks ago. 
+
+  🙈
+
+  [Schedule your next tea time here](<%= new_tt_url %>). 
+  (Or readjust your hosting commitment [here](<%= commitment_url %>).)
+
+  Obviously we think one of those options is way cooler than the other, but we’ll leave that to you. 
+
+  See you soon!  
+  TWS Robots
+<% end %>

--- a/app/views/host_mailer/host_drip_reminder.markerb
+++ b/app/views/host_mailer/host_drip_reminder.markerb
@@ -1,0 +1,24 @@
+<% commitment = @host.commitment_detail %>
+<% half_commitment = commitment % 2 == 0 ? commitment / 2 : commitment.to_f / 2 %>
+<% new_tt_url = url_for(controller: :tea_times, action: :new, only_path: false) %>
+<% commitment_url = url_for(controller: :registrations, action: :edit, only_path: false) %>
+<% case @drip_index %>
+<% when 0 %>
+  Just a nudge because emails get lost sometimes. [Here's that link again :)](<%= new_tt_url %>).
+
+  Try for sometime before <%= (@tt.start_time + commitment.weeks).strftime("%B %e") %> to keep up the commitment to hosting every <%= commitment %> weeks. No harm done if you can’t host til after that.*
+
+  Automatedly yours,  
+  TWS Robots
+
+  *If you’d like to change your commitment frequency, [you can do that here](<%= commitment_url %>).
+<% when 2 %>
+  👋 
+
+  Bumping this email in case you filed it away to check back later. 
+
+  [Here’s that link to create a new tea time](<%= new_tt_url %>). 
+
+  Zip zoom zap!  
+  TWS Robots
+<% end %>

--- a/app/views/host_mailer/inactive_host_posted.markerb
+++ b/app/views/host_mailer/inactive_host_posted.markerb
@@ -1,0 +1,9 @@
+<% commitment_url = url_for(controller: :registrations, action: :edit, only_path: false) %>
+Just noticed you posted your first tea time since you mentioned that you weren’t hosting any longer. If this might be a sign for things to come, yay! [Head on over to the website and adjust your hosting commitment](<%= commitment_url %>).
+
+You don’t have to make any promises to how often you host, but just switching out of the “I’m not hosting anymore” option would be dandy. That way, we can send you more relevant updates about TWS.  
+
+If this was just a one off tea, still dope! Glad you’re here 🤗
+
+That’s all,  
+TWS Robots

--- a/app/views/host_mailer/no_commitment_drip.markerb
+++ b/app/views/host_mailer/no_commitment_drip.markerb
@@ -1,0 +1,30 @@
+<% new_tt_url = url_for(controller: :tea_times, action: :new, only_path: false) %>
+<% case @drip_index %>
+<% when 0 %>
+  Hey, it’s been a few weeks since we last saw you hosting. If you are… 
+
+  - craving another great conversation,
+  - pondering a question and you want to hear what others have to say,
+  - getting tired of seeing the same people on the reg,
+  - searching for an excuse to go to a new cafe, 
+  - looking for a good story, or
+  - generally itching for some reason or another…
+
+  [This might help](<%= new_tt_url %>).
+
+  (Hint: it’s a link to schedule another tea time. The more ahead of time you plan the tea, the more likely it is to fill up!)
+
+  Zip slip bop,  
+  TWS Robots
+
+  PS We keep host pictures up on the site for a month after their last tea time since it helps keep the site more accurate for hosts and attendees (as far as who’s hosting and who’s not). If you post another tea time by <%= (@tt.start_time + RefreshHostActivityStatus::ACTIVE_EXPIRATION).strftime("%B %e") %>, you’ll stick around! Otherwise, your face will grace the <%= @host.home_city.name %> page again when you are able to post another tea time.
+<% else %>
+  Hi hello hey! It’s been months since we’ve seen you. If you’ve been feeling some kinda way lately and think a tea time would do you some good, don’t be bashful.
+
+  [Host a tea time in the next month](<%= new_tt_url %>)! It’s good for the soul. And we miss your face.
+
+  If now’s not a good time, it’s all right. We’ll send you another note in a little while. 
+
+  Bleep bleep bloop,  
+  TWS Robots
+<% end %>

--- a/app/views/host_mailer/no_commitment_drip_reminder.markerb
+++ b/app/views/host_mailer/no_commitment_drip_reminder.markerb
@@ -1,0 +1,13 @@
+<% new_tt_url = url_for(controller: :tea_times, action: :new, only_path: false) %>
+<% commitment_url = url_for(controller: :registrations, action: :edit, only_path: false) %>
+
+Just a nudge in case you filed the last email away to come back to later. 
+
+📅 [Here’s that link to schedule a tea time](<%= new_tt_url %>)
+
+We won’t email you again for a few months about hosting tea time, but if you like reminders, you should set a hosting commitment on the website. [Here’s the link to do that](<%= commitment_url %>).
+
+When you do, you’ll get emails in accordance with your commitment reminding you to host tea times when you’re able to. You can adjust or eliminate the commitment whenever.
+
+🖖,  
+TWS Robots 

--- a/app/views/host_mailer/pause.markerb
+++ b/app/views/host_mailer/pause.markerb
@@ -1,0 +1,12 @@
+<% commitment_url = url_for(controller: :registrations, action: :edit, only_path: false) %>
+
+Hey, we just heard that you won’t be hosting anymore. Totally understand, but just wanted to check in — should we still be letting you know what’s the latest in the world of Tea With Strangers by email?
+
+Let us know by filling out [this form](https://goo.gl/forms/vIXoVpOI6Dx2N2jC3). It’ll take 5 seconds, but it’ll let us know that you’re still interested in what’s going on in our world so we can be sure to get that info to you!
+
+If not, you’ll probably see the occasional facebook notification, but nothing else otherwise. 
+
+TTFN,  
+TWS Robots
+
+PS If you change your mind at any point, just [head here and change your hosting commitment](<%= commitment_url %>) accordingly :)

--- a/app/views/profiles/_set_host_commitment.html.erb
+++ b/app/views/profiles/_set_host_commitment.html.erb
@@ -1,0 +1,31 @@
+<div class="edit-host-commitment sidebar-section">
+  <% if current_user.commitment.nil? %>
+    <div class='title orange'>
+      !!!
+    </div>
+    <div class='details'>
+      <span>
+        <b>How often do you plan to host tea time?</b> Set your Host Commitment on the
+        <a href='/users/edit'>Account Details</a> page.
+      </span>
+      <%= link_to 'Set Hosting Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
+    </div>
+  <% else %>
+    <div class='title'>
+      Hosting Commitment
+    </div>
+    <div class='details'>
+      <% if HostDetail::IRREGULAR_COMMITMENTS.include?(current_user.commitment) %>
+        <span>
+          If you want to host more regularly, set your Hosting Commitment here.
+        </span>
+        <%= link_to 'Set Hosting Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
+      <% else %>
+        <span>
+          <%= "Thanks so much for hosting tea times <b>every #{current_user.commitment} weeks</b>.".html_safe %>
+        </span>
+        <%= link_to 'Change Your Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/profiles/host_tasks.html.erb
+++ b/app/views/profiles/host_tasks.html.erb
@@ -17,9 +17,7 @@
         You look real good today.
       </h3>
     </div>
-    <div class="create-new-tea sidebar-section">
-      <%= link_to 'Create New Tea Time!', new_tea_time_path, class: "button create-new-tea" %>
-    </div>
+    <%= render partial: 'set_host_commitment' %>
   </div>
   <div class="dash-body">
     <h2>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,37 +17,7 @@
           You look real good today.
         </h3>
       </div>
-      <div class="edit-host-commitment sidebar-section">
-        <% if current_user.commitment.nil? %>
-          <div class='title orange'>
-            !!!
-          </div>
-          <div class='details'>
-            <span>
-              <b>How often do you plan to host tea time?</b> Set your Host Commitment on the
-              <a href='/users/edit'>Account Details</a> page.
-            </span>
-            <%= link_to 'Set Hosting Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
-          </div>
-        <% else %>
-          <div class='title'>
-            Hosting Commitment
-          </div>
-          <div class='details'>
-            <% if HostDetail::IRREGULAR_COMMITMENTS.include?(current_user.commitment) %>
-              <span>
-                If you want to host more regularly, set your Hosting Commitment here.
-              </span>
-              <%= link_to 'Set Hosting Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
-            <% else %>
-              <span>
-                <%= "Thanks so much for hosting tea times <b>every #{current_user.commitment} weeks</b>.".html_safe %>
-              </span>
-              <%= link_to 'Change Your Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <%= render partial: 'set_host_commitment' %>
     <% else %>
       <% if !@attending.count.zero? %>
         <% if !current_user.home_city.nil? %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,16 +17,37 @@
           You look real good today.
         </h3>
       </div>
-      <% if !@hosting.count.zero? %>
-        <div class="create-new-tea sidebar-section">
-          <%= link_to 'Create Another Tea Time', new_tea_time_path, class: "button create-new-tea" %>
-        </div>
-      <% else %>
-        <div class="create-new-tea sidebar-section">
-          <%= link_to 'Create A Tea Time', new_tea_time_path, class: "button create-new-tea" %>
-        </div>
-      <% end %>
-
+      <div class="edit-host-commitment sidebar-section">
+        <% if current_user.commitment.nil? %>
+          <div class='title orange'>
+            !!!
+          </div>
+          <div class='details'>
+            <span>
+              <b>How often do you plan to host tea time?</b> Set your Host Commitment on the
+              <a href='/users/edit'>Account Details</a> page.
+            </span>
+            <%= link_to 'Set Hosting Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
+          </div>
+        <% else %>
+          <div class='title'>
+            Hosting Commitment
+          </div>
+          <div class='details'>
+            <% if HostDetail::IRREGULAR_COMMITMENTS.include?(current_user.commitment) %>
+              <span>
+                If you want to host more regularly, set your Hosting Commitment here.
+              </span>
+              <%= link_to 'Set Hosting Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
+            <% else %>
+              <span>
+                <%= "Thanks so much for hosting tea times <b>every #{current_user.commitment} weeks</b>.".html_safe %>
+              </span>
+              <%= link_to 'Change Your Commitment', url_for('/users/edit'), class: 'button create-new-tea' %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <% if !@attending.count.zero? %>
         <% if !current_user.home_city.nil? %>

--- a/spec/factories/host_details.rb
+++ b/spec/factories/host_details.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :host_detail, class: 'HostDetail' do
     association :user, factory: [:user, :host]
     activity_status 0
+    commitment 0
 
     trait :inactive do
     end

--- a/spec/factories/tea_times.rb
+++ b/spec/factories/tea_times.rb
@@ -20,6 +20,10 @@ FactoryGirl.define do
       followup_status :cancelled
     end
 
+    trait :completed do
+      followup_status :completed
+    end
+
     trait :attended do
       transient { attendee_count 3 }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,6 +18,10 @@ FactoryGirl.define do
         nickname "Joe #{t.capitalize}"
         family_name "#{t.capitalize}"
 
+        after :create do |u|
+          FactoryGirl.create(:host_detail, :user => u)
+        end
+
         after :build do |u|
           u.roles << t
         end

--- a/spec/mailers/host_mailer_spec.rb
+++ b/spec/mailers/host_mailer_spec.rb
@@ -1,16 +1,10 @@
 require 'spec_helper'
 
 describe HostMailer do
-  describe '.pre_tea_time_nudge' do
-    let(:host) do
-      u = create(:user)
-      u.roles << :host
-      u
-    end
-    let(:tea_time_id) do
-      create(:tea_time, user_id: host.id).id
-    end
+  let(:host) { create(:user, :host) }
+  let(:tea_time_id) { create(:tea_time, user_id: host.id).id }
 
+  describe '.pre_tea_time_nudge' do
     let(:cancelled_tea_time) do
       create(:tea_time, user_id: host.id, followup_status: :cancelled)
     end
@@ -47,6 +41,231 @@ describe HostMailer do
           expect(mail.text_part.body.raw_source).not_to be_empty
         end
       end
+    end
+  end
+
+  describe '.host_drip' do
+    before(:each) do
+      hd = host.host_detail
+      hd.commitment = 5
+      hd.save!
+    end
+
+    it 'doesn\'t send without tt' do
+      described_class.host_drip(tea_time_id + 1, 0).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if host has irregular commitmnet' do
+      hd = host.host_detail
+      hd.commitment = -1
+      hd.save!
+      described_class.host_drip(tea_time_id, 0).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'sends first reminder' do
+      mail = described_class.host_drip(tea_time_id, 0)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Your next tea time")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+
+    it 'sends second reminder' do
+      mail = described_class.host_drip(tea_time_id, 1)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Hi there")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+
+    it 'sends third reminder' do
+      mail = described_class.host_drip(tea_time_id, 2)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Moving oolong 🍵")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+
+    it 'sends repeating reminder' do
+      mail = described_class.host_drip(tea_time_id, 5)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("🤗: Knock knock! 🤔: Who’s there?")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
+
+  describe '.host_drip_reminder' do
+    before(:each) do
+      hd = host.host_detail
+      hd.commitment = 5
+      hd.save!
+    end
+
+    it 'doesn\'t send without tt' do
+      described_class.host_drip_reminder(tea_time_id + 1, 0).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if host has irregular commitmnet' do
+      hd = host.host_detail
+      hd.commitment = -1
+      hd.save!
+      described_class.host_drip_reminder(tea_time_id, 0).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'sends first reminder' do
+      mail = described_class.host_drip_reminder(tea_time_id, 0)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Your next tea time")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+
+    it 'sends third reminder' do
+      mail = described_class.host_drip_reminder(tea_time_id, 2)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Moving oolong 🍵")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
+
+  describe '.no_commitment_drip' do
+    before(:each) do
+      hd = host.host_detail
+      hd.commitment = 0
+      hd.save!
+    end
+
+    it 'doesn\'t send without tt' do
+      described_class.no_commitment_drip(tea_time_id + 1, 0).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if host has a commitment' do
+      hd = host.host_detail
+      hd.commitment = 4
+      hd.save!
+      described_class.no_commitment_drip(tea_time_id, 0).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'sends first reminder' do
+      mail = described_class.no_commitment_drip(tea_time_id, 0)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Thinking about ya")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+
+    it 'sends repeating reminder' do
+      mail = described_class.no_commitment_drip(tea_time_id, 5)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("It’s been a while!")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
+
+  describe '.no_commitment_drip_reminder' do
+    before(:each) do
+      hd = host.host_detail
+      hd.commitment = 0
+      hd.save!
+    end
+
+    it 'doesn\'t send without host' do
+      described_class.no_commitment_drip_reminder(host.id + 1).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if host has a commitment' do
+      hd = host.host_detail
+      hd.commitment = 4
+      hd.save!
+      described_class.no_commitment_drip_reminder(host.id).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'sends first reminder' do
+      mail = described_class.no_commitment_drip_reminder(host.id)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Thinking about ya")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
+
+  describe '.pause' do
+    before(:each) do
+      hd = host.host_detail
+      hd.commitment = -1
+      hd.save!
+    end
+
+    it 'doesn\'t send without host' do
+      described_class.pause(host.id + 1).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if not inactive commitment' do
+      hd = host.host_detail
+      hd.commitment = 4
+      hd.save!
+      described_class.pause(host.id).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'sends' do
+      mail = described_class.pause(host.id)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("We just heard the news…")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
+
+  describe '.inactive_host_posted' do
+    before(:each) do
+      hd = host.host_detail
+      hd.commitment = -1
+      hd.save!
+      tt = TeaTime.find(tea_time_id)
+      tt.start_time = Time.now + 1.day
+      tt.save!
+    end
+
+    it 'doesn\'t send without host' do
+      described_class.inactive_host_posted(host.id + 1).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if not inactive commitment' do
+      hd = host.host_detail
+      hd.commitment = 4
+      hd.save!
+      described_class.inactive_host_posted(host.id).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'doesn\'t send if no future teas posted' do
+      tt = TeaTime.find(tea_time_id)
+      tt.start_time = Time.now - 1.day
+      tt.save!
+      described_class.inactive_host_posted(host.id).deliver
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
+    it 'sends' do
+      mail = described_class.inactive_host_posted(host.id)
+      mail.deliver
+      expect(mail.to).to eq [host.email]
+      expect(mail.subject).to eql("Hello again!")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -232,4 +232,116 @@ describe User do
       end
     end
   end
+
+  context '.send_drip_email' do
+    let!(:host) { create(:user, :host) }
+    context 'does not send' do
+      it 'with inactive commitment' do
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+        host.host_detail.destroy
+        create(:host_detail, :user => host, :commitment => HostDetail::INACTIVE_COMMITMENT)
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 3.weeks)
+        host.send_drip_email(tea_time)
+      end
+
+      it 'with no commitment' do
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 3.weeks)
+        host.send_drip_email(tea_time)
+      end
+
+      it 'with no tea time' do
+        host.host_detail.destroy
+        create(:host_detail, :user => host, :commitment => HostDetail::NO_COMMITMENT)
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+        host.send_drip_email(nil)
+      end
+    end
+
+    context 'with every 4 weeks commitment' do
+      before(:each) do
+        host.host_detail.destroy
+        create(:host_detail, :user => host, :commitment => 4)
+      end
+
+      it 'sends first email after 2 weeks' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 2.weeks)
+        expect(HostMailer).to receive(:host_drip).with(tea_time.id, 0).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends first reminder after 2 weeks and 2 days' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 2.weeks - 2.days)
+        expect(HostMailer).to receive(:host_drip_reminder).with(tea_time.id, 0).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends second email after 4 weeks' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 4.weeks)
+        expect(HostMailer).to receive(:host_drip).with(tea_time.id, 1).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends third email after 6 weeks' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 6.weeks)
+        expect(HostMailer).to receive(:host_drip).with(tea_time.id, 2).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends third reminder after 6 weeks and 2 days' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 6.weeks - 2.days)
+        expect(HostMailer).to receive(:host_drip_reminder).with(tea_time.id, 2).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends recurring reminder after 8 weeks' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 8.weeks)
+        expect(HostMailer).to receive(:host_drip).with(tea_time.id, 3).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends recurring reminder after 24 weeks' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 24.weeks)
+        expect(HostMailer).to receive(:host_drip).with(tea_time.id, 7).and_call_original
+        host.send_drip_email(tea_time)
+      end
+    end
+
+    context 'with no commitment' do
+      before(:each) do
+        host.host_detail.destroy
+        create(:host_detail, :user => host, :commitment => HostDetail::NO_COMMITMENT)
+      end
+
+      it 'sends first email after 3 weeks' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 3.weeks)
+        expect(HostMailer).to receive(:no_commitment_drip).with(tea_time.id, 0).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends first reminder after 3 weeks + 2 days' do
+        expect(HostMailer).to receive(:no_commitment_drip_reminder).with(host.id).and_call_original
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 3.weeks - 2.days)
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends recurring reminder after 3 months' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 3.months)
+        expect(HostMailer).to receive(:no_commitment_drip).with(tea_time.id, 1).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends recurring reminder after 6 months' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 6.months)
+        expect(HostMailer).to receive(:no_commitment_drip).with(tea_time.id, 2).and_call_original
+        host.send_drip_email(tea_time)
+      end
+
+      it 'sends recurring reminder after 15 months' do
+        tea_time = create(:tea_time, :completed, :host => host, :start_time => Time.now - 15.months)
+        expect(HostMailer).to receive(:no_commitment_drip).with(tea_time.id, 5).and_call_original
+        host.send_drip_email(tea_time)
+      end
+    end
+  end
 end


### PR DESCRIPTION
3 main things:
- update Account Details to allow hosts to set a host commitment
- add commitment edit functionality to dashboard 
- update city page visibility

all is done according to [this spec](https://docs.google.com/document/d/1x-FGvNez_v0zrKgtD3dOQo1JTB742ZVY3LOqIPPvWyo/edit#heading=h.h7v44f580bwm)

### ACCOUNT DETAILS
![image](https://cloud.githubusercontent.com/assets/1581186/23740125/085156ca-0457-11e7-8b63-d5ad9f712a37.png)
![image](https://cloud.githubusercontent.com/assets/1581186/23740349/0e6cb0da-0458-11e7-8d2b-94282854e583.png)



### EDIT FROM DASHBOARD
with a commitment:
![image](https://cloud.githubusercontent.com/assets/1581186/23740137/1a4d08b0-0457-11e7-98b4-8c97086c7a84.png)

with "when i want" or "don't plan to host"
![image](https://cloud.githubusercontent.com/assets/1581186/23740318/e87b74b0-0457-11e7-857c-836a77d0cb18.png)


with nothing set yet (for launch)
![image](https://cloud.githubusercontent.com/assets/1581186/23740308/dd5d6372-0457-11e7-91e7-ce7e74122c0b.png)


