### PR TITLE
generate host_detail when user is upgraded to a host

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -40,6 +40,7 @@ class HostsController < ApplicationController
 
     if @host.save
       UserMailer.delay.host_registration(@host, user_exists ? nil : generated_password)
+      @host.generate_host_detail
       redirect_to profile_path, notice: 'New host successfully created and emailed!'
     else
       redirect_to new_host_path, alert: 'New host not created :/'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,6 @@ class User < ActiveRecord::Base
   validates_with Validators::TwitterHandleValidator
 
   before_destroy :flake_future
-  after_create :generate_host_detail
 
   bitmask :roles, :as => [:host, :admin], :null => false
   alias_method :role?, :roles?
@@ -86,7 +85,7 @@ class User < ActiveRecord::Base
   end
 
   def generate_host_detail
-    HostDetail.create(user: self)
+    HostDetail.create(user: self) unless host_detail
   end
 
   def waitlist

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,6 +18,10 @@ FactoryGirl.define do
         nickname "Joe #{t.capitalize}"
         family_name "#{t.capitalize}"
 
+        after :create do |u|
+          FactoryGirl.create(:host_detail, :user => u)
+        end
+
         after :build do |u|
           u.roles << t
         end


### PR DESCRIPTION
We were creating the host_detail when a new user was created, but that didn't cover the case of an old user being upgraded to a host

@ankitshah811 @nickbarnwell 