### PR TITLE
add www subdomain to password reset link

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -4,7 +4,7 @@
 
 <p>Looks like you forgot the password on Tea With Strangers for your account with this email: <%= @resource.email %>.</p>
 
-<p><%= link_to 'Click here to change your password', edit_password_url(@resource, reset_password_token: @token) %>, but if you didn't actually ask to reset your password. Ignore the email. Somebody might just be playing games with you.</p>
+<p><%= link_to 'Click here to change your password', edit_password_url(@resource, reset_password_token: @token, :subdomain => 'www') %>, but if you didn't actually ask to reset your password. Ignore the email. Somebody might just be playing games with you.</p>
 
 <p>Your password won't change until you access the link above and create a new one.</p>
 


### PR DESCRIPTION
Potentially fixes issue with link in password reset email where link is directed to the tws.com server rather than the www.tws.com server.

I'm not familiar with this language or framework, and the generated code nonsense makes it pretty inscrutable, but according to some french guy on stack overflow this should work: https://stackoverflow.com/questions/9238301/adding-www-to-devise-emails-or-rails-in-general. 

As far as I can tell, the black magic here is:
- http://www.rubydoc.info/github/plataformatec/devise/master/Devise/Controllers/UrlHelpers to route to a helper rails has generated, which is eventually being generated by
- [url_for](https://apidock.com/rails/v2.3.8/ActionController/Base/url_for), for whom
- "the full request with all the HTTP headers are made available to the action through accessor methods" (https://apidock.com/rails/ActionController/Base)
- and the request object [includes the url object](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/request.rb#L24)
- which has a string typed subdomain property.
But for sure run the thing before pushing it to prod -_-

Note that doing it this way locks this application into being hosted on a www subdomain.  Possibly more reliable solutions:

- forwarding the root domain to heroku. 
I believe you're hosted on name.com, so that would involve https://devcenter.heroku.com/articles/custom-domains#add-a-custom-root-domain and https://www.name.com/support/articles/115010493967-Adding-an-ANAME-Alias-record.  I'm not sure this strategy would allow you to preserve the MX records on tws.com, which would probably be bad.

- domain host url forwarding
it looks like tws.com is actually running some random php server.  Potentially, that's the server running the name.com [url forwarding service](https://www.name.com/support/articles/205188658-Adding-URL-Forwarding).  If it isn't, and it's something you've rolled on your own, you should ...probably not be doing that.  The fundamental problem is that the url forwarder on tws.com is only forwarding tws.com/ rather than all routes on tws.com/* to www.tws.com.  The docs don't say explicitly that you can get it to forward all routes, but it'd be pretty stupid for them to not have implemented that functionality.  I would try tweaking the config and maybe calling up name.com to figure out if you actually can't do this through them.  If that worked, that would be ideal.