### PR TITLE
Change Production Host to www.tws.com

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: 'teawithstrangers.com' }
+  config.action_mailer.default_url_options = { host: 'www.teawithstrangers.com' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address: 'smtp.sendgrid.net',


### PR DESCRIPTION
A simpler fix for #721 - all of our emails will now have www.teawithstrangers.com as the host for any `url_for` or `*_url` calls