### PR TITLE
next month tea display

### DIFF
--- a/app/assets/javascripts/tea_times.js
+++ b/app/assets/javascripts/tea_times.js
@@ -1,0 +1,16 @@
+/**
+ * Bind the tea time month navigation links (e.g. "see next month tea times")
+ */
+var bindTeaTimeMonthLink = function() {
+  $('#tea-time-month-next').on('click', function(e) {
+    e.preventDefault();
+    $(this).closest('.month-display-container').removeClass('show-left').addClass('show-right');
+  });
+
+  $('#tea-time-month-prev').on('click', function(e) {
+    e.preventDefault();
+    $(this).closest('.month-display-container').removeClass('show-right').addClass('show-left');
+  });
+};
+
+$(document).on('turbolinks:load', bindTeaTimeMonthLink)

--- a/app/assets/stylesheets/components/_tea-time.scss
+++ b/app/assets/stylesheets/components/_tea-time.scss
@@ -5,6 +5,45 @@ tea times across the website.
 
 */
 
+/// THIS CSS IS BROKEN AND NEEDS @MARKBAO'S ATTENTION
+
+.visibility-container {
+	@include span-columns(12 of 12);
+}
+
+.month-display-container {
+	position: relative;
+	overflow: visible;
+	clear: both;
+}
+
+.month-display {
+	width: 100%;
+	float: left;
+	clear: both;
+	position: absolute;
+	top: 0;
+	&.show {
+		&.left {
+			left: 0%;
+		}
+		&.right {
+			left: 0%;
+		}
+	}
+
+	&.hidden {
+		&.left {
+			left: -120%;
+		}
+		&.right {
+			left: 120%;
+		}
+	}
+}
+
+/// </end>
+
 .tt-page-only {
 	display: none;
 }
@@ -253,7 +292,7 @@ tea times across the website.
 		@extend %vertical-center-flex-container;
 	    @include padding(83px 0);
 		margin-top: 1em;
-		border: 1px solid lighten($tws-orange,15);
+		border: 2px solid lighten($tws-orange,15);
 
 		h3 {
 			font-size: 1.25em;
@@ -273,15 +312,41 @@ tea times across the website.
 	}
 }
 
-.city-jump {
-	margin: 1em 0;
+.jump {
+	margin: 1em -1em;
 	text-align: center;
-	overflow: auto;
+	overflow: visible;
 
 	@include media($tablet) {
 
 		@include span-columns(12 of 12);
 		margin-right: 0;
+	}
+
+	.month-selector {
+		overflow: auto;
+		border-bottom: 1px solid $tws-yellow;
+		padding: 0.5em 1em;
+		text-transform: uppercase;
+		font-weight: 600;
+		font-size: 0.8em;
+		a {
+			cursor: pointer;
+			border-bottom: 1px solid;
+		}
+		.month {
+			@include span-columns(6 of 12);
+			@include omega(2n);
+		}
+		.showing {
+			text-align: left;
+		}
+		.previous {
+
+		}
+		.click {
+			text-align: right;
+		}
 	}
 
 	.jump-box {

--- a/app/assets/stylesheets/components/_tea-time.scss
+++ b/app/assets/stylesheets/components/_tea-time.scss
@@ -349,6 +349,10 @@ Contains an individual month container.
 		.month {
 			@include span-columns(6 of 12);
 			@include omega(2n);
+
+			span.light {
+				color: lighten($tws-orange,15);
+			}
 		}
 		.showing {
 			text-align: left;

--- a/app/assets/stylesheets/components/_tea-time.scss
+++ b/app/assets/stylesheets/components/_tea-time.scss
@@ -5,44 +5,56 @@ tea times across the website.
 
 */
 
-/// THIS CSS IS BROKEN AND NEEDS @MARKBAO'S ATTENTION
-
+/*
+Contains the .month-display-container, which is 200% of the width of this
+container. Overflow is hidden. .month-display-container will translate its own
+content.
+ */
 .visibility-container {
 	@include span-columns(12 of 12);
+    width: 100%;
+    overflow: hidden;
 }
 
+/*
+Contains the two month display containers.
+
+The width of this container is 200% of the parent container, allowing it to
+contain the two .month-display containers each as 50% of this container,
+appearing side-by-side (the left and right containers).
+
+Initially has show-left class. When the show-right class is set, it translates
+-50% on the x axis to move the right container into view. The overflow is
+hidden by .visibility-container.
+ */
 .month-display-container {
+    @include clearfix;
 	position: relative;
 	overflow: visible;
 	clear: both;
+    width: 200%;
+    transition: transform 0.5s ease-in-out;
+
+    // Show left month container (default)
+    &.show-left {
+        transform: translate(0%);
+    }
+
+    // Show right month container (shift entire container left 50%)
+    &.show-right {
+        transform: translate(-50%);
+    }
 }
 
+/*
+Contains an individual month container.
+ */
 .month-display {
-	width: 100%;
-	float: left;
-	clear: both;
-	position: absolute;
-	top: 0;
-	&.show {
-		&.left {
-			left: 0%;
-		}
-		&.right {
-			left: 0%;
-		}
-	}
-
-	&.hidden {
-		&.left {
-			left: -120%;
-		}
-		&.right {
-			left: 120%;
-		}
-	}
+	width: 50%;
+    display: inline-block;
+    float: left;
+    vertical-align: top;
 }
-
-/// </end>
 
 .tt-page-only {
 	display: none;
@@ -313,7 +325,7 @@ tea times across the website.
 }
 
 .jump {
-	margin: 1em -1em;
+	margin: 1em 0;
 	text-align: center;
 	overflow: visible;
 

--- a/app/models/tea_time.rb
+++ b/app/models/tea_time.rb
@@ -34,6 +34,7 @@ class TeaTime < ActiveRecord::Base
   scope :future_until, ->(until_time) { future.before(until_time) }
   scope :not_cancelled, -> { where("followup_status != 3") }
   scope :this_month, -> { after(Date.today).before(Time.now.at_end_of_month).not_cancelled }
+  scope :next_month, -> { after(Date.today.at_beginning_of_month.next_month).before(Time.now.at_beginning_of_month.next_month.at_end_of_month).not_cancelled }
 
   def date
     start_time.strftime("%A, %D")

--- a/app/views/tea_times/index.html.erb
+++ b/app/views/tea_times/index.html.erb
@@ -31,7 +31,7 @@
     <div class="tt-intro">
       
       <!--Revisit copy later -->
-      <% if @tea_times_by_city.empty? %>
+      <% if @this_month[:tea_times_by_city].empty? %>
         <p>
           No tea times scheduled for this month! Check back later.
         </p>
@@ -65,7 +65,11 @@
                 📅 The rest of <%= month_name %> 
               </div>
               <div class="month click next">
-                🔮  <a name="next" id="tea-time-month-next" href="#">See <%= next_month_name %>'s tea times →</a>
+                <% if @next_month.nil? %>
+                  View next month&rsquo;s tea times in <%= @days_until_next_month %> days
+                <% else %>
+                  🔮  <a name="next" id="tea-time-month-next" href="#">See <%= next_month_name %>'s tea times →</a>
+                <% end %>
               </div>
             </div>
             <div class="jump-box notification alert">
@@ -73,15 +77,15 @@
                 Jump to Your City's Tea Times
               </h5>
               <div class="jump-city-list">
-                <% @cities.each do |city| %>
-                  <a href="#<%= @city_to_city_code[city].parameterize %>"><%= city %></a>
+                <% @this_month[:cities].each do |city| %>
+                  <a href="#<%= @this_month[:city_to_city_code][city].parameterize %>" data-turbolinks="false"><%= city %></a>
                 <% end %>
               </div>
             </div>
           </div>
           <div class="tt-all current-month">
-            <% @tea_times_by_city.each do |city, tts| %>
-              <a name="<%= @city_to_city_code[city].parameterize %>"></a>
+            <% @this_month[:tea_times_by_city].each do |city, tts| %>
+              <a name="<%= @this_month[:city_to_city_code][city].parameterize %>"></a>
               <div class="tt-set-container">
                 <div class="city-title-holder tt-grid-unit">
                   <h3>
@@ -101,33 +105,31 @@
             <% end %>
           </div>
         </div>
-        <div class="month-display right">
-          <div class="jump">
-            <div class="month-selector">
-              <div class="month showing next">
-                📅 Tea times in <%= next_month_name %>
+        <% unless @next_month.nil? %>
+          <div class="month-display right">
+            <div class="jump">
+              <div class="month-selector">
+                <div class="month showing next">
+                  📅 Tea times in <%= next_month_name %>
+                </div>
+                <div class="month click now">
+                  🧘🏽‍♀️ <a name="next" id="tea-time-month-prev" href="#">←  See this month's tea times</a>
+                </div>
               </div>
-              <div class="month click now">
-                🧘🏽‍♀️ <a name="next" id="tea-time-month-prev" href="#">←  See this month's tea times</a>
-              </div>
-            </div>
-            <div class="jump-box notification alert">
-              <h5 class="strong">
-                Jump to Your City's Tea Times
-              </h5>
-              <div class="jump-city-list">
-                <!--ONLY SHOW CITIES WITH TEA TIMES IN NEXT MONTH -->
-                  <% @cities.each do |city| %>
-                    <a href="#<%= @city_to_city_code[city].parameterize %>"><%= city %></a>
+              <div class="jump-box notification alert">
+                <h5 class="strong">
+                  Jump to Your City's Tea Times
+                </h5>
+                <div class="jump-city-list">
+                  <% @next_month[:cities].each do |city| %>
+                    <a href="#<%= @next_month[:city_to_city_code][city].parameterize %>-next-month" data-turbolinks="false"><%= city %></a>
                   <% end %>
-                <!--ONLY SHOW CITIES WITH TEA TIMES IN NEXT MONTH -->
+                </div>
               </div>
             </div>
-          </div>
-          <div class="tt-all">
-            <!--ONLY SHOW TEA TIMES IN NEXT MONTH -->
-              <% @tea_times_by_city.each do |city, tts| %>
-                <a name="<%= @city_to_city_code[city].parameterize %>"></a>
+            <div class="tt-all">
+              <% @next_month[:tea_times_by_city].each do |city, tts| %>
+                <a name="<%= @next_month[:city_to_city_code][city].parameterize %>-next-month"></a>
                 <div class="tt-set-container">
                   <div class="city-title-holder tt-grid-unit">
                     <h3>
@@ -145,9 +147,9 @@
                   <% end %>
                 </div>
               <% end %>
-            <!--ONLY SHOW TEA TIMES IN NEXT MONTH -->
+            </div>
           </div>
-        </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/tea_times/index.html.erb
+++ b/app/views/tea_times/index.html.erb
@@ -66,7 +66,7 @@
               </div>
               <div class="month click next">
                 <% if @next_month.nil? %>
-                  View next month&rsquo;s tea times in <%= @days_until_next_month %> days
+                  <span class="light">(<%= next_month_name %>'s tea times will be available in <%= @days_until_next_month %> days)</span>
                 <% else %>
                   🔮  <a name="next" id="tea-time-month-next" href="#">See <%= next_month_name %>'s tea times →</a>
                 <% end %>

--- a/app/views/tea_times/index.html.erb
+++ b/app/views/tea_times/index.html.erb
@@ -57,15 +57,15 @@
       <% end %>
     </div>
     <div class="visibility-container">
-      <div class="month-display-container">
-        <div class="month-display show left">
+      <div class="month-display-container show-left">
+        <div class="month-display left">
           <div class="jump">
             <div class="month-selector">
               <div class="month showing now">
                 📅 The rest of <%= month_name %> 
               </div>
               <div class="month click next">
-                🔮  <a name="next">See <%= next_month_name %>'s tea times →</a>
+                🔮  <a name="next" id="tea-time-month-next" href="#">See <%= next_month_name %>'s tea times →</a>
               </div>
             </div>
             <div class="jump-box notification alert">
@@ -101,14 +101,14 @@
             <% end %>
           </div>
         </div>
-        <div class="month-display hidden right">
+        <div class="month-display right">
           <div class="jump">
             <div class="month-selector">
               <div class="month showing next">
                 📅 Tea times in <%= next_month_name %>
               </div>
               <div class="month click now">
-                🧘🏽‍♀️ <a name="next">←  See this month's tea times</a>
+                🧘🏽‍♀️ <a name="next" id="tea-time-month-prev" href="#">←  See this month's tea times</a>
               </div>
             </div>
             <div class="jump-box notification alert">

--- a/app/views/tea_times/index.html.erb
+++ b/app/views/tea_times/index.html.erb
@@ -51,43 +51,104 @@
           </p>
         <% else %>
           <p> 
-            If none of these work for you, come back <%= next_month_name %> 1, or you can <%= link_to "apply to be a Host", hosting_path %>!
+            If none of these work for you, check back in <%= next_month_name %>, or you can <%= link_to "apply to be a Host", hosting_path %>!
           </p>
         <% end %>
       <% end %>
     </div>
-    <div class="city-jump">
-      <div class="jump-box notification alert">
-        <h5 class="strong">
-          Jump to Your City's Tea Times
-        </h5>
-        <div class="jump-city-list">
-          <% @cities.each do |city| %>
-            <a href="#<%= @city_to_city_code[city].parameterize %>"><%= city %></a>
-          <% end %>
+    <div class="visibility-container">
+      <div class="month-display-container">
+        <div class="month-display show left">
+          <div class="jump">
+            <div class="month-selector">
+              <div class="month showing now">
+                📅 The rest of <%= month_name %> 
+              </div>
+              <div class="month click next">
+                🔮  <a name="next">See <%= next_month_name %>'s tea times →</a>
+              </div>
+            </div>
+            <div class="jump-box notification alert">
+              <h5 class="strong">
+                Jump to Your City's Tea Times
+              </h5>
+              <div class="jump-city-list">
+                <% @cities.each do |city| %>
+                  <a href="#<%= @city_to_city_code[city].parameterize %>"><%= city %></a>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <div class="tt-all current-month">
+            <% @tea_times_by_city.each do |city, tts| %>
+              <a name="<%= @city_to_city_code[city].parameterize %>"></a>
+              <div class="tt-set-container">
+                <div class="city-title-holder tt-grid-unit">
+                  <h3>
+                    <%= city %>
+                    <br>
+                    👉
+                  </h3>
+                </div>
+                <% tts.each do |tt| %>
+                  <div class="tt-grid-unit">
+                    <%= link_to tea_time_path(tt) do %>
+                      <%= render partial: 'shared/tea_time_row', locals: {tea_time: tt, no_signin_button: true} %>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="month-display hidden right">
+          <div class="jump">
+            <div class="month-selector">
+              <div class="month showing next">
+                📅 Tea times in <%= next_month_name %>
+              </div>
+              <div class="month click now">
+                🧘🏽‍♀️ <a name="next">←  See this month's tea times</a>
+              </div>
+            </div>
+            <div class="jump-box notification alert">
+              <h5 class="strong">
+                Jump to Your City's Tea Times
+              </h5>
+              <div class="jump-city-list">
+                <!--ONLY SHOW CITIES WITH TEA TIMES IN NEXT MONTH -->
+                  <% @cities.each do |city| %>
+                    <a href="#<%= @city_to_city_code[city].parameterize %>"><%= city %></a>
+                  <% end %>
+                <!--ONLY SHOW CITIES WITH TEA TIMES IN NEXT MONTH -->
+              </div>
+            </div>
+          </div>
+          <div class="tt-all">
+            <!--ONLY SHOW TEA TIMES IN NEXT MONTH -->
+              <% @tea_times_by_city.each do |city, tts| %>
+                <a name="<%= @city_to_city_code[city].parameterize %>"></a>
+                <div class="tt-set-container">
+                  <div class="city-title-holder tt-grid-unit">
+                    <h3>
+                      <%= city %>
+                      <br>
+                      👉
+                    </h3>
+                  </div>
+                  <% tts.each do |tt| %>
+                    <div class="tt-grid-unit">
+                      <%= link_to tea_time_path(tt) do %>
+                        <%= render partial: 'shared/tea_time_row', locals: {tea_time: tt, no_signin_button: true} %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            <!--ONLY SHOW TEA TIMES IN NEXT MONTH -->
+          </div>
         </div>
       </div>
-    </div>
-    <div class="tt-all">
-      <% @tea_times_by_city.each do |city, tts| %>
-        <a name="<%= @city_to_city_code[city].parameterize %>"></a>
-        <div class="tt-set-container">
-          <div class="city-title-holder tt-grid-unit">
-            <h3>
-              <%= city %>
-              <br>
-              👉
-            </h3>
-          </div>
-          <% tts.each do |tt| %>
-            <div class="tt-grid-unit">
-              <%= link_to tea_time_path(tt) do %>
-                <%= render partial: 'shared/tea_time_row', locals: {tea_time: tt, no_signin_button: true} %>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
not complete yet, and needs @markbao to do the following:

- [ ] Populate query to render next month's data 
   - [ ] cities with tea times in the next month in 'Jump to Your City' box
   - [ ] tea times for the next month in the `month-display` div
- [ ] troubleshoot CSS or find workaround to render the current and next month displays "side by side" and hide one while showing the other 
- [ ] correctly link the 'see next month's tea times' and 'see this month's tea times' buttons

You'll see that I've gotten the two month displays side by side with a hacky `position:absolute` sort of solution. I'm not sure it's the best way of doing things. I don't care for it to be a solution that takes a long time to implement. If the solution to making this work isn't obvious to you, @markbao, we can drop the 'slide left' 'slide right' idea entirely and just have them fade out / fade in with a `display:block` attribute instead of using the `left:0` `left:-100%` etc solution I've proposed here

![2018-06-23 at 10 23 pm](https://user-images.githubusercontent.com/1022843/41816215-0b7e5752-7734-11e8-88ef-7a7ea01107c0.png)
